### PR TITLE
Add/disabling input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ To disable automatically changing status, set these two config parameters to `No
 | `asset_import_create_device_type` | `False` | When importing a device type asset, automatically create manufacturer and/or device type if it doesn't exist |
 | `asset_import_create_module_type` | `False` | When importing a module type asset, automatically create manufacturer and/or device type if it doesn't exist |
 | `asset_import_create_inventoryitem_type` | `False` | When importing an inventory type asset, automatically create manufacturer and/or device type if it doesn't exist |
+| `asset_disable_editing_fields_for_tags` | `{}` | A dictionary of tags and fields that should be disabled for editing. This is useful if you want to prevent editing of certain fields for certain assets. The dictionary is in the form of `{tag: [field1, field2]}`. Example: `{'no-edit': ['serial_number', 'asset_tag']}`. This only affects the UI, the API can still be used to edit the fields. |
+| `asset_disable_deletion_for_tags` | `[]` | List of tags that will disable deletion of assets. This only affects the UI, not the API. |
 
 
 ### Future development ideas
 
-- add option to lock editing certain Asset fields if asset has certain tag. also prevent Asset delete
 - location report
 - supplier detail - show assets
 - device on_delete update asset.status (if asset assigned)

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -19,6 +19,9 @@ class NetBoxInventoryConfig(PluginConfig):
         'asset_import_create_device_type': False,
         'asset_import_create_module_type': False,
         'asset_import_create_inventoryitem_type': False,
+        'asset_disable_editing_fields_for_tags': {},
+        'asset_disable_deletion_for_tags': [],
     }
+
 
 config = NetBoxInventoryConfig

--- a/netbox_inventory/forms/models.py
+++ b/netbox_inventory/forms/models.py
@@ -11,14 +11,16 @@ __all__ = (
     'InventoryItemTypeForm',
 )
 
+
 class AssetForm(NetBoxModelForm):
+
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
         required=False,
         initial_params={
             'device_types': '$device_type',
             'module_types': '$module_type',
-        }
+        },
     )
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
@@ -40,7 +42,7 @@ class AssetForm(NetBoxModelForm):
         query_params={
             'manufacturer_id': '$manufacturer',
         },
-        label='Inventory item type'
+        label='Inventory item type',
     )
     owner = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
@@ -57,7 +59,7 @@ class AssetForm(NetBoxModelForm):
         required=False,
         initial_params={
             'locations': '$storage_location',
-        }
+        },
     )
     storage_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
@@ -70,19 +72,58 @@ class AssetForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        ('General', ('name', 'asset_tag', 'status')),
-        ('Hardware', ('serial', 'manufacturer', 'device_type', 'module_type', 'inventoryitem_type')),
-        ('Purchase', ('owner', 'supplier', 'order_number', 'purchase_date', 'warranty_start', 'warranty_end')),
-        ('Location', ('storage_site', 'storage_location',)),
+        ('General', ('name', 'asset_tag', 'tags', 'status')),
+        (
+            'Hardware',
+            (
+                'serial',
+                'manufacturer',
+                'device_type',
+                'module_type',
+                'inventoryitem_type',
+            ),
+        ),
+        (
+            'Purchase',
+            (
+                'owner',
+                'supplier',
+                'order_number',
+                'purchase_date',
+                'warranty_start',
+                'warranty_end',
+            ),
+        ),
+        (
+            'Location',
+            (
+                'storage_site',
+                'storage_location',
+            ),
+        ),
     )
 
     class Meta:
         model = Asset
         fields = (
-            'name', 'asset_tag', 'serial', 'status', 'manufacturer',
-            'device_type', 'module_type', 'inventoryitem_type', 'storage_location',
-            'owner', 'supplier', 'order_number', 'purchase_date', 'warranty_start',
-            'warranty_end', 'tags', 'comments', 'storage_site',
+            'name',
+            'asset_tag',
+            'serial',
+            'status',
+            'manufacturer',
+            'device_type',
+            'module_type',
+            'inventoryitem_type',
+            'storage_location',
+            'owner',
+            'supplier',
+            'order_number',
+            'purchase_date',
+            'warranty_start',
+            'warranty_end',
+            'tags',
+            'comments',
+            'storage_site',
         )
         widgets = {
             'purchase_date': DatePicker(),
@@ -117,14 +158,15 @@ class SupplierForm(NetBoxModelForm):
     slug = SlugField()
     comments = CommentField()
 
-    fieldsets = (
-        ('Supplier', ('name', 'description', 'tags')),
-    )
+    fieldsets = (('Supplier', ('name', 'description', 'tags')),)
 
     class Meta:
         model = Supplier
         fields = (
-            'name', 'description', 'comments', 'tags',
+            'name',
+            'description',
+            'comments',
+            'tags',
         )
 
 
@@ -133,11 +175,19 @@ class InventoryItemTypeForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        ('Inventory Item Type', ('manufacturer', 'model', 'slug', 'part_number', 'tags')),
+        (
+            'Inventory Item Type',
+            ('manufacturer', 'model', 'slug', 'part_number', 'tags'),
+        ),
     )
 
     class Meta:
         model = InventoryItemType
         fields = (
-            'manufacturer', 'model', 'slug', 'part_number', 'tags', 'comments',
+            'manufacturer',
+            'model',
+            'slug',
+            'part_number',
+            'tags',
+            'comments',
         )

--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -10,6 +10,7 @@ __all__ = (
     'InventoryItemTypeTable',
 )
 
+
 class AssetTable(NetBoxTable):
     name = tables.Column(
         linkify=True,
@@ -56,11 +57,11 @@ class AssetTable(NetBoxTable):
             manufacturer=Coalesce(
                 'device_type__manufacturer',
                 'module_type__manufacturer',
-                'inventoryitem_type__manufacturer'
+                'inventoryitem_type__manufacturer',
             )
         ).order_by(
             ('-' if is_descending else '') + 'manufacturer',
-            ('-' if is_descending else '') + 'serial'
+            ('-' if is_descending else '') + 'serial',
         )
         return (queryset, True)
 
@@ -68,37 +69,65 @@ class AssetTable(NetBoxTable):
         queryset, _ = self.order_manufacturer(queryset, is_descending)
         queryset = queryset.annotate(
             model=Coalesce(
-                'device_type__model',
-                'module_type__model',
-                'inventoryitem_type__model'
+                'device_type__model', 'module_type__model', 'inventoryitem_type__model'
             )
         ).order_by(
             ('-' if is_descending else '') + 'manufacturer',
             ('-' if is_descending else '') + 'model',
-            ('-' if is_descending else '') + 'serial'
+            ('-' if is_descending else '') + 'serial',
         )
         return (queryset, True)
 
     def order_hardware(self, queryset, is_descending):
         queryset = queryset.annotate(
-            hw=Coalesce('device__name', 'module__device__name', 'inventoryitem__device__name')
+            hw=Coalesce(
+                'device__name', 'module__device__name', 'inventoryitem__device__name'
+            )
         ).order_by(
             ('-' if is_descending else '') + 'hw',
             ('-' if is_descending else '') + 'module__module_bay',
-            ('-' if is_descending else '') + 'serial'
+            ('-' if is_descending else '') + 'serial',
         )
         return (queryset, True)
 
     class Meta(NetBoxTable.Meta):
         model = Asset
         fields = (
-            'pk', 'id', 'name', 'asset_tag', 'serial', 'status',
-            'kind', 'manufacturer', 'hardware_type', 'hardware',
-            'tenant', 'contact', 'storage_location',
-            'owner', 'supplier', 'order_number', 'purchase_date', 'warranty_start', 'warranty_end',
-            'tags', 'created', 'last_updated',  'actions'
+            'pk',
+            'id',
+            'name',
+            'asset_tag',
+            'serial',
+            'status',
+            'kind',
+            'manufacturer',
+            'hardware_type',
+            'hardware',
+            'tenant',
+            'contact',
+            'storage_location',
+            'owner',
+            'supplier',
+            'order_number',
+            'purchase_date',
+            'warranty_start',
+            'warranty_end',
+            'tags',
+            'created',
+            'last_updated',
+            'actions',
         )
-        default_columns = ('name', 'serial', 'kind', 'manufacturer', 'hardware_type', 'asset_tag', 'status', 'hardware')
+        default_columns = (
+            'name',
+            'serial',
+            'kind',
+            'manufacturer',
+            'hardware_type',
+            'asset_tag',
+            'status',
+            'hardware',
+            'tags',
+        )
 
 
 class SupplierTable(NetBoxTable):

--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -145,10 +145,21 @@ class SupplierTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Supplier
         fields = (
-            'pk', 'id', 'name', 'description', 'comments', 'asset_count',
-            'tags', 'created', 'last_updated',  'actions'
+            'pk',
+            'id',
+            'name',
+            'description',
+            'comments',
+            'asset_count',
+            'tags',
+            'created',
+            'last_updated',
+            'actions',
         )
-        default_columns = ('name', 'asset_count',)
+        default_columns = (
+            'name',
+            'asset_count',
+        )
 
 
 class InventoryItemTypeTable(NetBoxTable):
@@ -169,7 +180,22 @@ class InventoryItemTypeTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = InventoryItemType
         fields = (
-            'pk', 'id', 'manufacturer', 'model', 'slug', 'part_number',
-            'comments', 'tags', 'created', 'last_updated',  'actions', 'asset_count'
+            'pk',
+            'id',
+            'manufacturer',
+            'model',
+            'slug',
+            'part_number',
+            'comments',
+            'tags',
+            'created',
+            'last_updated',
+            'actions',
+            'asset_count',
         )
-        default_columns = ('name', 'manufacturer', 'model', 'asset_count',)
+        default_columns = (
+            'name',
+            'manufacturer',
+            'model',
+            'asset_count',
+        )

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -41,12 +41,9 @@ def get_tags_that_protect_asset_from_deletion():
     Returns:
         list: list of tag slug strings
     """
-    tags = settings.PLUGINS_CONFIG['netbox_inventory'][
+    return settings.PLUGINS_CONFIG['netbox_inventory'][
         'asset_disable_deletion_for_tags'
     ]
-    if not tags:
-        return []
-    return tags
 
 
 def get_tags_and_edit_protected_asset_fields():
@@ -65,9 +62,8 @@ def get_tags_and_edit_protected_asset_fields():
     Returns:
         dict: dict of tag slug strings and list of field names
     """
-    tags = settings.PLUGINS_CONFIG['netbox_inventory'][
+    return settings.PLUGINS_CONFIG['netbox_inventory'][
         'asset_disable_editing_fields_for_tags'
     ]
-    if not tags:
-        return []
-    return tags
+
+

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -4,10 +4,9 @@ from django.core.exceptions import ImproperlyConfigured
 from .choices import InventoryStatusChoices
 
 
-
 def get_prechange_field(obj, field_name):
-    """ Get value from obj._prechange_snapshot. If field is a relation,
-        return object instance.
+    """Get value from obj._prechange_snapshot. If field is a relation,
+    return object instance.
     """
     value = getattr(obj, '_prechange_snapshot', {}).get(field_name)
     if value is None:
@@ -23,11 +22,13 @@ def get_prechange_field(obj, field_name):
 
 
 def get_status_for(status):
-    status_name = settings.PLUGINS_CONFIG['netbox_inventory'][status+'_status_name']
+    status_name = settings.PLUGINS_CONFIG['netbox_inventory'][status + '_status_name']
     if status_name is None:
         return None
     if status_name not in dict(InventoryStatusChoices):
-        raise ImproperlyConfigured(f'Configuration defines status {status_name}, but not defined in InventoryStatusChoices')
+        raise ImproperlyConfigured(
+            f'Configuration defines status {status_name}, but not defined in InventoryStatusChoices'
+        )
     return status_name
 
 

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -29,3 +29,44 @@ def get_status_for(status):
     if status_name not in dict(InventoryStatusChoices):
         raise ImproperlyConfigured(f'Configuration defines status {status_name}, but not defined in InventoryStatusChoices')
     return status_name
+
+
+def get_tags_that_protect_asset_from_deletion():
+    """Return a list of tags that prevent an asset from being deleted.
+
+    Which tags prevent deletion is defined in the plugin configuration,
+    under the key ``asset_disable_deletion_for_tags``.
+
+    Returns:
+        list: list of tag slug strings
+    """
+    tags = settings.PLUGINS_CONFIG['netbox_inventory'][
+        'asset_disable_deletion_for_tags'
+    ]
+    if not tags:
+        return []
+    return tags
+
+
+def get_tags_and_edit_protected_asset_fields():
+    """Return a dict of tags and fields that prevent editing specified fields.
+
+    Which tags prevent editing is defined in the plugin configuration,
+    under the key ``asset_disable_editing_fields_for_tags``.
+
+    Structure of the dict is::
+
+        {
+            'tag_slug': ['field1', 'field2'],
+            'tag_slug2': ['field1', 'field4'],
+        }
+
+    Returns:
+        dict: dict of tag slug strings and list of field names
+    """
+    tags = settings.PLUGINS_CONFIG['netbox_inventory'][
+        'asset_disable_editing_fields_for_tags'
+    ]
+    if not tags:
+        return []
+    return tags

--- a/netbox_inventory/views/asset.py
+++ b/netbox_inventory/views/asset.py
@@ -5,12 +5,16 @@ from django.shortcuts import redirect, render
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
-from dcim.models import Device, InventoryItem, Module
 from extras.signals import clear_webhooks
 from netbox.views import generic
 from utilities.exceptions import PermissionsViolation
-from utilities.forms import restrict_form_fields
+from utilities.forms import ConfirmationForm, restrict_form_fields
+
 from .. import filtersets, forms, models, tables
+from ..utils import (
+    get_tags_and_edit_protected_asset_fields,
+    get_tags_that_protect_asset_from_deletion,
+)
 
 __all__ = (
     'AssetView',
@@ -44,6 +48,31 @@ class AssetEditView(generic.ObjectEditView):
 class AssetDeleteView(generic.ObjectDeleteView):
     queryset = models.Asset.objects.all()
 
+    def post(self, request, *args, **kwargs):
+        """Override post method to check if asset is protected from deletion"""
+        logger = logging.getLogger('netbox.netbox_inventory.views.AssetDeleteView')
+        asset = self.get_object(**kwargs)
+        protected_tags = set(get_tags_that_protect_asset_from_deletion())
+        asset_tags = set(asset.tags.all().values_list('slug', flat=True))
+        intersection_of_tags = set(asset_tags).intersection(protected_tags)
+
+        if intersection_of_tags:
+            error_msg = "Cannot delete asset {} protected by tags: {}.".format(
+                asset.name,
+                ", ".join(intersection_of_tags),
+            )
+            logger.info(error_msg)
+            messages.warning(request, error_msg)
+
+            form = ConfirmationForm(request.POST)
+            if form.is_valid():
+                return_url = form.cleaned_data.get('return_url')
+                if return_url and return_url.startswith('/'):
+                    return redirect(return_url)
+                return redirect(self.get_return_url(request, asset))
+            return redirect(asset.get_absolute_url())
+        return super().post(request, *args, **kwargs)
+
 
 class AssetBulkImportView(generic.BulkImportView):
     queryset = models.Asset.objects.all()
@@ -57,10 +86,106 @@ class AssetBulkEditView(generic.BulkEditView):
     table = tables.AssetTable
     form = forms.AssetBulkEditForm
 
+    def post(self, request, **kwargs):
+        """Override post method to check if assets are protected from editing"""
+
+        logger = logging.getLogger('netbox.views.BulkEditView')
+
+        # If we are editing *all* objects in the queryset, replace the PK list with all matched objects.
+        if request.POST.get('_all') and self.filterset is not None:
+            pk_list = self.filterset(
+                request.GET, self.queryset.values_list('pk', flat=True)
+            ).qs
+        else:
+            pk_list = request.POST.getlist('pk')
+
+        # Include the PK list as initial data for the form
+        initial_data = {'pk': pk_list}
+        protected_fields_by_tags = get_tags_and_edit_protected_asset_fields()
+
+        errors = []
+        protected_asset_names = []
+
+        if '_apply' in request.POST:
+            form = self.form(request.POST, initial=initial_data)
+            restrict_form_fields(form, request.user)
+
+            if form.is_valid():
+                nullified_fields = set(request.POST.getlist('_nullify'))
+
+                queryset = self.queryset.filter(pk__in=pk_list)
+
+                for obj in queryset:
+                    obj_tags = set(obj.tags.all().values_list('slug', flat=True))
+                    intersection_of_tags = set(obj_tags).intersection(
+                        protected_fields_by_tags.keys()
+                    )
+
+                    # Check if asset is protected from editing
+                    for tag in intersection_of_tags:
+                        # TODO: Check if custom fields can be protected
+                        protected_fields = set(protected_fields_by_tags[tag])
+
+                        modified_fields = set(form.changed_data)
+                        nullable = set(form.nullable_fields).intersection(
+                            set(nullified_fields)
+                        )
+
+                        if modified_fields.intersection(
+                            protected_fields
+                        ) or nullable.intersection(protected_fields):
+                            protected_asset_names.append(obj.name)
+
+                            fields = modified_fields.intersection(
+                                protected_fields
+                            ).union(nullable.intersection(protected_fields))
+                            errors.append(
+                                "Cannot edit asset '{}' fields protected by tag '{}': {}.".format(
+                                    obj.name,
+                                    tag,
+                                    ','.join(fields),
+                                )
+                            )
+                if errors:
+                    error_msg_protected_assets = f"Edit failed for all assets. Because of trying to modify protected fields on assets: {', '.join(set(protected_asset_names))}."
+                    logger.info(errors + [error_msg_protected_assets])
+                    messages.warning(request, ' '.join(errors))
+                    messages.warning(request, error_msg_protected_assets)
+                    return redirect(self.get_return_url(request))
+        return super().post(request, **kwargs)
+
 
 class AssetBulkDeleteView(generic.BulkDeleteView):
     queryset = models.Asset.objects.all()
     table = tables.AssetTable
+
+    def post(self, request, *args, **kwargs):
+        """Override post method to check if assets are protected from deletion"""
+        logger = logging.getLogger('netbox.views.BulkDeleteView')
+        model = self.queryset.model
+        if request.POST.get('_all'):
+            qs = model.objects.all()
+            if self.filterset is not None:
+                qs = self.filterset(request.GET, qs).qs
+            pk_list = qs.only('pk').values_list('pk', flat=True)
+        else:
+            pk_list = [int(pk) for pk in request.POST.getlist('pk')]
+
+        queryset = self.queryset.filter(pk__in=pk_list)
+
+        protected_tags = set(get_tags_that_protect_asset_from_deletion())
+        protected_assets = queryset.filter(tags__slug__in=protected_tags)
+
+        if protected_assets:
+            protected_asset_names = protected_assets.values_list('name', flat=True)
+            error_msg = "Cannot delete assets protected by tags: {}. Assets that can't be deleted: {}".format(
+                ', '.join(protected_tags), ', '.join(protected_asset_names)
+            )
+            logger.info(error_msg)
+            messages.warning(request, error_msg)
+            return redirect(self.get_return_url(request))
+
+        return super().post(request, *args, **kwargs)
 
 
 class AssetAssignView(generic.ObjectEditView):

--- a/netbox_inventory/views/asset.py
+++ b/netbox_inventory/views/asset.py
@@ -1,10 +1,11 @@
 import logging
+
+from dcim.models import Device, InventoryItem, Module
 from django.contrib import messages
 from django.db import transaction
 from django.shortcuts import redirect, render
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-
 from extras.signals import clear_webhooks
 from netbox.views import generic
 from utilities.exceptions import PermissionsViolation
@@ -205,14 +206,15 @@ class AssetAssignView(generic.ObjectEditView):
 
 class AssetCreateHardwareView(generic.ObjectEditView):
     """
-        Creates device/module/inventory item and assigns it to selected asset
+    Creates device/module/inventory item and assigns it to selected asset
 
-        Dynamically sets queryset, template and form, based on asset.kind
+    Dynamically sets queryset, template and form, based on asset.kind
 
-        Creates a new device/module/inventory item instance and assigns its
-        attr assigned_asset so it is accessible in form.
+    Creates a new device/module/inventory item instance and assigns its
+    attr assigned_asset so it is accessible in form.
 
     """
+
     queryset = models.Asset.objects.all()
     default_return_url = 'plugins:netbox_inventory:asset_list'
 
@@ -239,7 +241,7 @@ class AssetCreateHardwareView(generic.ObjectEditView):
             self.queryset = InventoryItem.objects.all()
             self.form = forms.AssetCreateInventoryItemForm
             self.template_name = 'netbox_inventory/asset_create_inventoryitem.html'
-        ret =  super().dispatch(request, *args, **kwargs)
+        ret = super().dispatch(request, *args, **kwargs)
         self._permission_action = 'add'
         return ret
 
@@ -254,7 +256,9 @@ class AssetCreateHardwareView(generic.ObjectEditView):
 
         Assigns created obj to asset after obj saved
         """
-        logger = logging.getLogger('netbox.netbox_inventory.views.AssetCreateHardwareView')
+        logger = logging.getLogger(
+            'netbox.netbox_inventory.views.AssetCreateHardwareView'
+        )
         obj = self.get_object(**kwargs)
 
         # Take a snapshot for change logging (if editing an existing object)
@@ -262,7 +266,7 @@ class AssetCreateHardwareView(generic.ObjectEditView):
             obj.snapshot()
 
         obj = self.alter_object(obj, request, args, kwargs)
-        
+
         form = self.form(data=request.POST, files=request.FILES, instance=obj)
         restrict_form_fields(form, request.user)
 
@@ -286,11 +290,13 @@ class AssetCreateHardwareView(generic.ObjectEditView):
 
                 msg = '{} {}'.format(
                     'Created' if object_created else 'Modified',
-                    self.queryset.model._meta.verbose_name
+                    self.queryset.model._meta.verbose_name,
                 )
                 logger.info(f"{msg} {obj} (PK: {obj.pk})")
                 if hasattr(obj, 'get_absolute_url'):
-                    msg = '{} <a href="{}">{}</a>'.format(msg, obj.get_absolute_url(), escape(obj))
+                    msg = '{} <a href="{}">{}</a>'.format(
+                        msg, obj.get_absolute_url(), escape(obj)
+                    )
                 else:
                     msg = '{} {}'.format(msg, escape(obj))
                 messages.success(request, mark_safe(msg))
@@ -308,9 +314,13 @@ class AssetCreateHardwareView(generic.ObjectEditView):
         else:
             logger.debug("Form validation failed")
 
-        return render(request, self.template_name, {
-            'object': obj,
-            'form': form,
-            'return_url': self.get_return_url(request, obj),
-            **self.get_extra_context(request, obj),
-        })
+        return render(
+            request,
+            self.template_name,
+            {
+                'object': obj,
+                'form': form,
+                'return_url': self.get_return_url(request, obj),
+                **self.get_extra_context(request, obj),
+            },
+        )


### PR DESCRIPTION
# Add protect fields from editing and instances from being deleted based on settings

In configuration you can now set:
- `asset_disable_deletion_for_tags` which will protect asset from being deleted if it has one of given tags assigned to them.
- `asset_disable_editing_fields_for_tags`  which will protect given fields from being edited. When editing one instance fields will be disabled. When bulk editing fields will not be disabled but editing will failed and appropriate message will be shown.


Example of configuration:
```python
PLUGINS_CONFIG = {
    'netbox_inventory': {
        'asset_disable_deletion_for_tags': ['active', 'test'],
        'asset_disable_editing_fields_for_tags': {
            'physical': ['serial', 'storage_location'],
            'test': ['owner', 'asset_tag'],
            'automator': ['owner', 'asset_tag'],
        }
    }
}
```