### PR TITLE
only show menu items if user has permissions

### DIFF
--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -66,21 +66,25 @@ menu_items = (
     PluginMenuItem(
         link='plugins:netbox_inventory:asset_list',
         link_text='Assets',
+        permissions=["netbox_inventory.view_asset"],
         buttons=asset_buttons,
     ),
     PluginMenuItem(
         link='plugins:netbox_inventory:supplier_list',
         link_text='Suppliers',
+        permissions=["netbox_inventory.view_supplier"],
         buttons=supplier_buttons,
     ),
     PluginMenuItem(
         link='plugins:netbox_inventory:purchase_list',
         link_text='Purchases',
+        permissions=["netbox_inventory.view_purchase"],
         buttons=purchase_buttons,
     ),
     PluginMenuItem(
         link='plugins:netbox_inventory:inventoryitemtype_list',
         link_text='Inventory Item Types',
+        permissions=["netbox_inventory.view_inventoryitemtype"],
         buttons=inventoryitemtype_buttons,
     ),
 )


### PR DESCRIPTION
for example - when not logged into netbox, menu items for plugin still showed up, but selecting any of them redirected to login screen

not menu items are hidden if user does not have view permission

