### PR TITLE
fix creating device from asset with tags

### DIFF
--- a/netbox_inventory/forms/create.py
+++ b/netbox_inventory/forms/create.py
@@ -52,8 +52,8 @@ class AssetCreateMixin:
         After we save new hardware (Device, Module, InventortyItem), we must update
         asset.device/.module/.intentory_item to reffer to this new hardware instance
         """
+        asset = self.instance.assigned_asset
         instance = super().save(*args)
-        asset = instance.assigned_asset
         asset.snapshot()
         setattr(asset, asset.kind, instance)
         asset.full_clean()


### PR DESCRIPTION
fix for #38 

when using create device from asset and assigning tags, assigned_asset field was cleared by BaseModelForm._save_m2m()

