### PR TITLE
when creating related objects, make sure to pass model value

### DIFF
--- a/netbox_inventory/forms/bulk.py
+++ b/netbox_inventory/forms/bulk.py
@@ -236,9 +236,10 @@ class AssetCSVForm(NetBoxModelCSVForm):
             if (get_plugin_setting('asset_import_create_device_type')
                 and self.data.get('hardware_kind') == 'device'):
                 DeviceType.objects.get_or_create(
-                    model=self.data.get('model_name'),
+                    model__iexact=self.data.get('model_name'),
                     manufacturer=self._get_or_create_manufacturer(),
                     defaults={
+                        'model': self.data.get('model_name'),
                         'slug': slugify(self.data.get('model_name')),
                         'part_number': self._get_clean_value('part_number'),
                         'comments': self._get_clean_value('model_comments'),
@@ -247,9 +248,10 @@ class AssetCSVForm(NetBoxModelCSVForm):
             if (get_plugin_setting('asset_import_create_module_type')
                 and self.data.get('hardware_kind') == 'module'):
                 ModuleType.objects.get_or_create(
-                    model=self.data.get('model_name'),
+                    model__iexact=self.data.get('model_name'),
                     manufacturer=self._get_or_create_manufacturer(),
                     defaults={
+                        'model': self.data.get('model_name'),
                         'part_number': self._get_clean_value('part_number'),
                         'comments': self._get_clean_value('model_comments'),
                     },
@@ -260,6 +262,7 @@ class AssetCSVForm(NetBoxModelCSVForm):
                     model__iexact=self.data.get('model_name'),
                     manufacturer=self._get_or_create_manufacturer(),
                     defaults={
+                        'model': self.data.get('model_name'),
                         'slug': slugify(self.data.get('model_name')),
                         'part_number': self._get_clean_value('part_number'),
                         'comments': self._get_clean_value('model_comments'),


### PR DESCRIPTION
On Asset import if `asset_import_create_inventoryitem_type` is enabled and InventoryItem Type does not exist, it is created with empty `model` field. This causes import to fail.

Fix for this and also enable case insensitive check for device type and modules type names.
