### PR TITLE
Updated navigation menu for NetBox 3.4

### DIFF
--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,4 +1,4 @@
-from extras.plugins import PluginMenuButton, PluginMenuItem
+from extras.plugins import PluginMenuItem, PluginMenu, PluginMenuButton
 from utilities.choices import ButtonColorChoices
 
 
@@ -71,7 +71,7 @@ inventoryitemgroup_buttons = [
     ),
 ]
 
-menu_items = (
+menu = (
     PluginMenuItem(
         link='plugins:netbox_inventory:asset_list',
         link_text='Assets',
@@ -102,4 +102,12 @@ menu_items = (
         permissions=["netbox_inventory.view_inventoryitemgroup"],
         buttons=inventoryitemgroup_buttons,
     ),
+)
+
+menu = PluginMenu(
+    label='Inventory',
+    groups=(
+        ('Asset Management', menu),
+    ),
+    icon_class='mdi mdi-clipboard-text-multiple-outline'
 )


### PR DESCRIPTION
Added a top level navigation element as it is now supported in NetBox 3.4 and moved all the links from the plugins menu to the new dedicated menu.

![image](https://user-images.githubusercontent.com/626365/213496920-59ccaa97-e593-4ad0-bad7-e198ae406284.png)
