### PR TITLE
Fix asset sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        netbox-version: ["v3.3.6", "develop"]
+        netbox-version: ["v3.4.2", "v3.3.6", "develop"]
     services:
       redis:
         image: redis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Run tests under netbox
-on: [push, pull_request]
+on: [push]
 jobs:
   test-netbox:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        netbox-version: ["v3.4.2", "v3.3.6", "develop"]
+        netbox-version: ["v3.4.4", "v3.3.10", "develop"]
     services:
       redis:
         image: redis

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ The idea is that an external system uses some assets stored in netbox_inventory,
 
 ## Compatibility
 
-This plugin requires netbox version 3.3 to work.
+This plugin requires netbox version 3.3 or more to work.
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|       3.3      |      1.0.x     |
-|       3.4      |    (none yet)  |
+|       3.3      |      1.1.x     |
+|       3.4      |   (none yet)   |
 
 ## Installing
 

--- a/netbox_inventory/forms/create.py
+++ b/netbox_inventory/forms/create.py
@@ -158,18 +158,17 @@ class AssetInventoryItemCreateForm(AssetCreateMixin, InventoryItemForm):
             self.fields['manufacturer'].choices = [(asset.inventoryitem_type.manufacturer.pk, asset.inventoryitem_type.manufacturer)]
 
     def clean(self):
-        cleaned_data = super().clean()
+        super().clean()
         component_set = None
         for field_name in COMPONENT_FIELDS:
-            field_value = cleaned_data.get(field_name)
+            field_value = self.cleaned_data.get(field_name)
             if field_value and component_set:
                 raise ValidationError('Only a single component can be selected')
             if field_value:
                 component_set = field_name
-                cleaned_data['component_type'] = ContentType.objects.get(app_label='dcim', model=field_name)
-                cleaned_data['component_id'] = field_value.pk
-                cleaned_data.pop(field_name)
-        return cleaned_data
+                self.cleaned_data['component_type'] = ContentType.objects.get(app_label='dcim', model=field_name)
+                self.cleaned_data['component_id'] = field_value.pk
+                self.cleaned_data.pop(field_name)
 
     def clean_manufacturer(self):
         return self.instance.assigned_asset.inventoryitem_type.manufacturer

--- a/netbox_inventory/models.py
+++ b/netbox_inventory/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from netbox.models import NetBoxModel
 from .choices import HardwareKindChoices, AssetStatusChoices
-from .utils import get_prechange_field, get_plugin_setting, get_status_for
+from .utils import asset_clear_old_hw, get_prechange_field, get_plugin_setting, get_status_for
 
 
 class Asset(NetBoxModel):
@@ -297,16 +297,13 @@ class Asset(NetBoxModel):
         # device, module... does not allow serial to be null
         new_serial = self.serial if self.serial else ''
         if not new_hw and old_hw:
-            old_hw.serial = ''
-            old_hw.asset_tag = None
-            old_hw.save()
+            # unassigned
+            asset_clear_old_hw(old_hw)
         elif new_hw and old_hw != new_hw:
             # assigned something, set its serial
             if old_hw:
                 # but first clear previous hw data
-                old_hw.serial = ''
-                old_hw.asset_tag = None
-                old_hw.save()
+                asset_clear_old_hw(old_hw)
             # if new_hw already has correct values, don't save it again
             new_hw_save = False
             if new_hw.serial != new_serial:

--- a/netbox_inventory/signals.py
+++ b/netbox_inventory/signals.py
@@ -32,7 +32,7 @@ def prevent_update_serial_asset_tag(instance, **kwargs):
         # don't enforce if sync not enabled
         return
     if asset.serial != instance.serial or asset.asset_tag != instance.asset_tag:
-        raise AbortRequest(f'Cannot change {asset.kind} serial and asset tag if asset is asigned. Please update via inventory > asset instead.')
+        raise AbortRequest(f'Cannot change {asset.kind} serial and asset tag if asset is assigned. Please update via inventory > asset instead.')
 
 
 @receiver(pre_delete, sender=Device)

--- a/netbox_inventory/signals.py
+++ b/netbox_inventory/signals.py
@@ -54,7 +54,10 @@ def free_assigned_asset(instance, **kwargs):
         asset = instance.assigned_asset
     except Asset.DoesNotExist:
         return
+    asset.snapshot()
     asset.status = stored_status
+    # also unassign that item from asset
+    setattr(asset, asset.kind, None)
     asset.full_clean()
     asset.save()
     logger.info(f'Asset marked as stored {asset}')

--- a/netbox_inventory/signals.py
+++ b/netbox_inventory/signals.py
@@ -41,7 +41,7 @@ def prevent_update_serial_asset_tag(instance, **kwargs):
 def free_assigned_asset(instance, **kwargs):
     """
     If a hardware (Device, Module or InventoryItem) has an Asset assigned and
-    that hardware is deleted, uspdate Asset.status to stored_status.
+    that hardware is deleted, update Asset.status to stored_status.
 
     Netbox handles deletion in a DB transaction, so if deletion failes for any
     reason, this status change will also be reverted.

--- a/netbox_inventory/tests/asset/test_models.py
+++ b/netbox_inventory/tests/asset/test_models.py
@@ -1,0 +1,155 @@
+from copy import deepcopy
+from django.conf import settings
+from django.test import override_settings, TestCase
+
+from dcim.models import Device, DeviceType, DeviceRole, Manufacturer, Site
+from utilities.exceptions import AbortRequest
+from netbox_inventory.models import Asset
+
+
+CONFIG_SYNC_ON = deepcopy(settings.PLUGINS_CONFIG)
+CONFIG_SYNC_ON['netbox_inventory']['sync_hardware_serial_asset_tag']=True
+CONFIG_SYNC_OFF = deepcopy(settings.PLUGINS_CONFIG)
+CONFIG_SYNC_OFF['netbox_inventory']['sync_hardware_serial_asset_tag']=False
+
+
+class TestAssetModel(TestCase):
+    def setUp(self):
+        self.site1 = Site.objects.create(
+            name='site1',
+            slug='site1',
+            status='active',
+        )
+        self.manufacturer1 = Manufacturer.objects.create(
+            name='manufacturer1',
+            slug='manufacturer1',
+        )
+        self.device_type1 = DeviceType.objects.create(
+            manufacturer=self.manufacturer1,
+            model='device_type1',
+            slug='device_type1'
+        )
+        self.device_role1 = DeviceRole.objects.create(
+            name='device_role1',
+            slug='device_role1'
+        )
+        self.asset1 = Asset.objects.create(
+            asset_tag='asset1',
+            serial='asset1',
+            status='stored',
+            device_type=self.device_type1,
+        )
+        self.device1 = Device.objects.create(
+            site=self.site1,
+            status='active',
+            device_type=self.device_type1,
+            device_role=self.device_role1,
+            name='device1',
+        )
+        self.device2 = Device.objects.create(
+            site=self.site1,
+            status='active',
+            device_type=self.device_type1,
+            device_role=self.device_role1,
+            name='device2',
+        )
+
+    @override_settings(PLUGINS_CONFIG=CONFIG_SYNC_ON)
+    def test_update_hardware_used_on(self):
+        # assign device to asset
+        self.asset1.snapshot()
+        self.asset1.device=self.device1
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.device1.serial, self.asset1.serial)
+        self.assertEqual(self.device1.asset_tag, self.asset1.asset_tag)
+        
+        # update asset serial updates device serial
+        self.asset1.snapshot()
+        self.asset1.serial = 'changed'
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.device1.serial, 'changed')
+        
+        # update device serial not allowed
+        self.device1.snapshot()
+        self.device1.serial = 'notallowed'
+        self.device1.full_clean()
+        with self.assertRaises(AbortRequest):
+            self.device1.save()
+        
+        # assign defferent device
+        self.assertEqual(self.asset1.device, self.device1)
+        self.asset1.snapshot()
+        self.asset1.device=self.device2
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.device1.refresh_from_db()
+        self.device2.refresh_from_db()
+        self.assertEqual(self.device1.serial, '')
+        self.assertEqual(self.device1.asset_tag, None)
+        self.assertEqual(self.device2.serial, self.asset1.serial)
+        self.assertEqual(self.device2.asset_tag, self.asset1.asset_tag)
+
+        # unassign device from asset
+        self.asset1.snapshot()
+        self.asset1.device = None
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.device1.refresh_from_db()
+        self.device2.refresh_from_db()
+        self.assertEqual(self.device1.serial, '')
+        self.assertEqual(self.device1.asset_tag, None)
+        self.assertEqual(self.device2.serial, '')
+        self.assertEqual(self.device2.asset_tag, None)
+
+
+    @override_settings(PLUGINS_CONFIG=CONFIG_SYNC_OFF)
+    def test_update_hardware_used_off(self):
+        # assign device to asset
+        self.asset1.snapshot()
+        self.asset1.device=self.device1
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.device1.serial, '')
+        self.assertEqual(self.device1.asset_tag, None)
+        
+        # update asset serial updates device serial
+        self.asset1.snapshot()
+        self.asset1.serial = 'changed'
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.device1.serial, '')
+        
+        # update device serial is allowed
+        self.device1.snapshot()
+        self.device1.serial = 'allowed'
+        self.device1.full_clean()
+        self.device1.save()
+        self.device1.refresh_from_db()
+        self.assertEqual(self.device1.serial, 'allowed')
+
+        # assign defferent device
+        self.assertEqual(self.asset1.device, self.device1)
+        self.asset1.snapshot()
+        self.asset1.device=self.device2
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.device1.refresh_from_db()
+        self.device2.refresh_from_db()
+        self.assertEqual(self.device1.serial, 'allowed')
+        self.assertEqual(self.device1.asset_tag, None)
+        self.assertEqual(self.device2.serial, '')
+        self.assertEqual(self.device2.asset_tag, None)
+
+        # unassign device from asset
+        self.asset1.snapshot()
+        self.asset1.device = None
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.device1.refresh_from_db()
+        self.device2.refresh_from_db()
+        self.assertEqual(self.device1.serial, 'allowed')
+        self.assertEqual(self.device1.asset_tag, None)
+        self.assertEqual(self.device2.serial, '')
+        self.assertEqual(self.device2.asset_tag, None)

--- a/netbox_inventory/tests/asset/test_models.py
+++ b/netbox_inventory/tests/asset/test_models.py
@@ -153,3 +153,26 @@ class TestAssetModel(TestCase):
         self.assertEqual(self.device1.asset_tag, None)
         self.assertEqual(self.device2.serial, '')
         self.assertEqual(self.device2.asset_tag, None)
+
+    def test_update_status(self):
+        self.asset1.snapshot()
+        self.asset1.device = self.device1
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.asset1.refresh_from_db()
+        self.assertEqual(self.asset1.status, 'used')
+        self.asset1.snapshot()
+        self.asset1.device = None
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.asset1.status, 'stored')
+
+    def test_status_device_deleted(self):
+        self.asset1.snapshot()
+        self.asset1.device = self.device1
+        self.asset1.full_clean()
+        self.asset1.save()
+        self.assertEqual(self.asset1.status, 'used')
+        self.device1.delete()
+        self.asset1.refresh_from_db()
+        self.assertEqual(self.asset1.status, 'stored')

--- a/netbox_inventory/tests/asset/test_views.py
+++ b/netbox_inventory/tests/asset/test_views.py
@@ -71,6 +71,12 @@ class AssetTestCase(
             'csv2,stored,device,manufacturer1,device_type1',
             'csv3,stored,device,manufacturer_csv,device_type_csv',
         )
+        cls.csv_update_data = (
+            'id,serial,status',
+            f'{asset1.pk},133,stored',
+            f'{asset2.pk},233,stored',
+            f'{asset3.pk},333,stored',
+        )
         cls.bulk_edit_data = {
             'status': 'retired',
         }

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -52,7 +52,7 @@ def get_status_for(status):
         return None
     if status_name not in dict(AssetStatusChoices):
         raise ImproperlyConfigured(
-            f'Configuration defines status {status_name}, but not defined in InventoryStatusChoices'
+            f'Configuration defines status {status_name}, but not defined in AssetStatusChoices'
         )
     return status_name
 

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.signals import pre_save
 
+from dcim.models import Device, Module, InventoryItem
 from .choices import AssetStatusChoices
 
 
@@ -84,3 +86,17 @@ def get_tags_and_edit_protected_asset_fields():
         dict: dict of tag slug strings and list of field names
     """
     return get_plugin_setting('asset_disable_editing_fields_for_tags')
+
+
+def asset_clear_old_hw(old_hw):
+    # need to temporarily disconnect signal receiver that prevents update of device serial if asset assigned
+    from .signals import prevent_update_serial_asset_tag
+    pre_save.disconnect(prevent_update_serial_asset_tag, sender=Device)
+    pre_save.disconnect(prevent_update_serial_asset_tag, sender=Module)
+    pre_save.disconnect(prevent_update_serial_asset_tag, sender=InventoryItem)
+    old_hw.serial = ''
+    old_hw.asset_tag = None
+    old_hw.save()
+    pre_save.connect(prevent_update_serial_asset_tag, sender=Device)
+    pre_save.connect(prevent_update_serial_asset_tag, sender=Module)
+    pre_save.connect(prevent_update_serial_asset_tag, sender=InventoryItem)


### PR DESCRIPTION
Fix issues related to changing asset and assigned hardware relations:

- when you tried to unassign device from asset it returned error: `'Cannot change device serial and asset tag if asset is assigned. Please update via inventory > asset instead.'`
- when a device assigned to an asset was deleted, the assigned asset status was not updated
- error when creating InventoryItem from Asset in netbox v3.4.2 and later (#55)
 