### PR TITLE
make top level menu configurable and support netbox 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Available settings:
 
 | Setting | Default value | Description |
 |---------|---------------|-------------|
+| `top_level_menu` | `True`| Add netbox-inventory to the top level of netbox navigation menu under Inventory heading. If set to False the plugin will add a menu item under the Plugins menu item. This setting is only valid under netbox v3.4 and newer.
 | `used_status_name` | `'used'`| Status that indicates asset is in use. See "Automatic management of asset status" below for more info on this setting.
 | `stored_status_name` | `'stored'`| Status that indicates asset is in storage. See "Automatic management of asset status" below for more info on this setting.
 | `sync_hardware_serial_asset_tag` | `False` | When an asset is assigned or unassigned to a device, module or inventory item, update its serial number and asset tag to be in sync with the asset? |

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -12,6 +12,7 @@ class NetBoxInventoryConfig(PluginConfig):
     base_url = 'inventory'
     min_version = '3.3.0'
     default_settings = {
+        'top_level_menu': True,
         'used_status_name': 'used',
         'stored_status_name': 'stored',
         'sync_hardware_serial_asset_tag': False,

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,3 +1,6 @@
+from packaging import version
+
+from django.conf import settings
 from extras.plugins import PluginMenuItem, PluginMenu, PluginMenuButton
 from utilities.choices import ButtonColorChoices
 
@@ -71,7 +74,7 @@ inventoryitemgroup_buttons = [
     ),
 ]
 
-menu = (
+menu_buttons = (
     PluginMenuItem(
         link='plugins:netbox_inventory:asset_list',
         link_text='Assets',
@@ -104,10 +107,18 @@ menu = (
     ),
 )
 
-menu = PluginMenu(
-    label='Inventory',
-    groups=(
-        ('Asset Management', menu),
-    ),
-    icon_class='mdi mdi-clipboard-text-multiple-outline'
-)
+current_version = version.parse(settings.VERSION)
+REQUIRED_VERSION = version.Version('3.4')
+# can't use utils.get_plugin_setting() here, get value manually
+if (current_version >= REQUIRED_VERSION and settings.PLUGINS_CONFIG['netbox_inventory']['top_level_menu']):
+    # add a top level entry
+    menu = PluginMenu(
+        label=f'Inventory',
+        groups=(
+            ('Asset Management', menu_buttons),
+        ),
+        icon_class='mdi mdi-clipboard-text-multiple-outline'
+    )
+else:
+    # display under plugins
+    menu_items = menu_buttons

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,8 +1,16 @@
 from packaging import version
 
 from django.conf import settings
-from extras.plugins import PluginMenuItem, PluginMenu, PluginMenuButton
+from extras.plugins import PluginMenuItem, PluginMenuButton
 from utilities.choices import ButtonColorChoices
+
+# compatibility with netbox v3.3 that does not have PluginMenu
+try:
+    from extras.plugins import PluginMenu
+    HAVE_MENU = True
+except ImportError:
+    HAVE_MENU = False
+    PluginMenu = PluginMenuItem
 
 
 asset_buttons = [
@@ -107,10 +115,8 @@ menu_buttons = (
     ),
 )
 
-current_version = version.parse(settings.VERSION)
-REQUIRED_VERSION = version.Version('3.4')
 # can't use utils.get_plugin_setting() here, get value manually
-if (current_version >= REQUIRED_VERSION and settings.PLUGINS_CONFIG['netbox_inventory']['top_level_menu']):
+if (HAVE_MENU and settings.PLUGINS_CONFIG['netbox_inventory']['top_level_menu']):
     # add a top level entry
     menu = PluginMenu(
         label=f'Inventory',


### PR DESCRIPTION
continuing from #48 and keeping in mind comment by @ryanmerolle I've added an option to add navigation items to it's own menu, or keep them under plugins as implemented in https://github.com/ryanmerolle/netbox-acls/pull/113

Also kept compatibility with netbox v3.3.x for now.
