### PR TITLE
add option to attach images to Asset and InventoryItemType

### DIFF
--- a/netbox_inventory/models.py
+++ b/netbox_inventory/models.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.forms import ValidationError
 from django.urls import reverse
@@ -172,6 +173,10 @@ class Asset(NetBoxModel):
 
     comments = models.TextField(
         blank=True
+    )
+
+    images = GenericRelation(
+        to='extras.ImageAttachment'
     )
 
     clone_fields = [
@@ -453,6 +458,9 @@ class InventoryItemType(NetBoxModel):
     )
     comments = models.TextField(
         blank=True
+    )
+    images = GenericRelation(
+        to='extras.ImageAttachment'
     )
 
     clone_fields = [

--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -123,6 +123,7 @@
       </div>
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% include 'inc/panels/image_attachments.html' %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
@@ -31,6 +31,7 @@
     <div class="col col-md-6">
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% include 'inc/panels/image_attachments.html' %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
Asset and InventoryItemType can now have images uploaded and attached. For implementation I used ModuleType from netbox core as an example.

No migration/database schema change is needed for GenericRelation fields.

closes #46