### PR TITLE
add option to assign contacts to supplier

### DIFF
--- a/netbox_inventory/filtersets.py
+++ b/netbox_inventory/filtersets.py
@@ -5,6 +5,7 @@ from dcim.filtersets import DeviceFilterSet, InventoryItemFilterSet, ModuleFilte
 from dcim.models import Manufacturer, DeviceType, ModuleType, Site, Location
 from netbox.filtersets import NetBoxModelFilterSet
 from utilities import filters
+from tenancy.filtersets import ContactModelFilterSet
 from tenancy.models import Contact, Tenant
 from .choices import HardwareKindChoices, AssetStatusChoices
 from .models import Asset, InventoryItemType, InventoryItemGroup, Purchase, Supplier
@@ -163,7 +164,7 @@ class AssetFilterSet(NetBoxModelFilterSet):
             )
 
 
-class SupplierFilterSet(NetBoxModelFilterSet):
+class SupplierFilterSet(NetBoxModelFilterSet, ContactModelFilterSet):
     class Meta:
         model = Supplier
         fields = (

--- a/netbox_inventory/forms/filters.py
+++ b/netbox_inventory/forms/filters.py
@@ -7,6 +7,7 @@ from utilities.forms import (
     DatePicker, DynamicModelMultipleChoiceField, MultipleChoiceField,
     StaticSelect, TagFilterField, BOOLEAN_WITH_BLANK_CHOICES
 )
+from tenancy.forms import ContactModelFilterForm
 from tenancy.models import Contact, Tenant
 from ..choices import HardwareKindChoices, AssetStatusChoices
 from ..models import Asset, InventoryItemType, InventoryItemGroup, Purchase, Supplier
@@ -165,8 +166,13 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
     tag = TagFilterField(model)
 
 
-class SupplierFilterForm(NetBoxModelFilterSetForm):
+class SupplierFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):
     model = Supplier
+    fieldsets = (
+        (None, ('q', 'filter_id', 'tag')),
+        ('Contacts', ('contact', 'contact_role', 'contact_group')),
+    )
+
     tag = TagFilterField(model)
 
 

--- a/netbox_inventory/models.py
+++ b/netbox_inventory/models.py
@@ -363,6 +363,9 @@ class Supplier(NetBoxModel):
         max_length=200,
         blank=True
     )
+    contacts = GenericRelation(
+        to='tenancy.ContactAssignment'
+    )
     comments = models.TextField(
         blank=True
     )

--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -2,6 +2,7 @@ from django.db.models.functions import Coalesce
 import django_tables2 as tables
 
 from netbox.tables import columns, NetBoxTable
+from tenancy.tables import ContactsColumnMixin
 from .models import Asset, InventoryItemType, InventoryItemGroup, Purchase, Supplier
 
 __all__ = (
@@ -162,7 +163,7 @@ class AssetTable(NetBoxTable):
         )
 
 
-class SupplierTable(NetBoxTable):
+class SupplierTable(ContactsColumnMixin, NetBoxTable):
     name = tables.Column(
         linkify=True,
     )
@@ -188,6 +189,7 @@ class SupplierTable(NetBoxTable):
             'slug',
             'description',
             'comments',
+            'contacts',
             'purchase_count',
             'asset_count',
             'tags',

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -40,6 +40,7 @@
     <div class="col col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% include 'inc/panels/contacts.html' %}
     </div>
   </div>
   <div class="row mb-3">


### PR DESCRIPTION
Supplier can have multiple contacts assigned, each with a role and priority. The same was as netbox Provider or Site model handle contacts assignment.

For REST API: Getting and manipulating contact assignments to Supplier is done via `/api/tenancy/contact-assignments/` URL where: `conntent_type=netbox_inventory.supplier`.

closes #61 
