### PR TITLE
make API endpoint accept null for optional keys that are relations

### DIFF
--- a/netbox_inventory/api/serializers.py
+++ b/netbox_inventory/api/serializers.py
@@ -16,17 +16,17 @@ class AssetSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_inventory-api:asset-detail'
     )
-    device_type = NestedDeviceTypeSerializer(required=False)
-    device = NestedDeviceSerializer(required=False)
-    module_type = NestedModuleTypeSerializer(required=False)
-    module = NestedModuleSerializer(required=False)
-    inventoryitem_type = NestedInventoryItemTypeSerializer(required=False) 
-    inventoryitem = NestedInventoryItemSerializer(required=False)
-    storage_location = NestedModuleSerializer(required=False)
-    purchase = NestedPurchaseSerializer(required=False)
-    tenant = NestedTenantSerializer(required=False)
-    contact = NestedContactSerializer(required=False)
-    owner = NestedTenantSerializer(required=False)
+    device_type = NestedDeviceTypeSerializer(required=False, allow_null=True, default=None)
+    device = NestedDeviceSerializer(required=False, allow_null=True, default=None)
+    module_type = NestedModuleTypeSerializer(required=False, allow_null=True, default=None)
+    module = NestedModuleSerializer(required=False, allow_null=True, default=None)
+    inventoryitem_type = NestedInventoryItemTypeSerializer(required=False, allow_null=True, default=None) 
+    inventoryitem = NestedInventoryItemSerializer(required=False, allow_null=True, default=None)
+    storage_location = NestedModuleSerializer(required=False, allow_null=True, default=None)
+    purchase = NestedPurchaseSerializer(required=False, allow_null=True, default=None)
+    tenant = NestedTenantSerializer(required=False, allow_null=True, default=None)
+    contact = NestedContactSerializer(required=False, allow_null=True, default=None)
+    owner = NestedTenantSerializer(required=False, allow_null=True, default=None)
 
 
     class Meta:
@@ -82,7 +82,7 @@ class InventoryItemTypeSerializer(NetBoxModelSerializer):
         view_name='plugins-api:netbox_inventory-api:inventoryitemtype-detail'
     )
     manufacturer = NestedManufacturerSerializer()
-    inventoryitem_group = NestedInventoryItemGroupSerializer(required=False)
+    inventoryitem_group = NestedInventoryItemGroupSerializer(required=False, allow_null=True, default=None)
     asset_count = serializers.IntegerField(read_only=True)
     
     class Meta:

--- a/netbox_inventory/tests/asset/test_api.py
+++ b/netbox_inventory/tests/asset/test_api.py
@@ -117,17 +117,22 @@ class AssetTest(
                 'serial': 'asset4',
                 'status': 'stored',
                 'device_type': device_type1.pk,
+                'device': None,
             },
             {
                 'name': 'Asset 5',
                 'serial': 'asset5',
                 'status': 'stored',
+                'device_type': None,
+                'device': None,
                 'module_type': module_type1.pk,
+                'module': None,
             },
             {
                 'name': 'Asset 6',
                 'serial': 'asset6',
                 'status': 'stored',
                 'inventoryitem_type': inventoryitem_type1.pk,
+                'inventoryitem': cls.inventoryitem1.pk,
             },
         ]


### PR DESCRIPTION
This makes for example POST asset endpoint accept:

```
{
    "serial": "1",
    "status": "stored",
    "device_type": 1,
    "device": null
}
```

Previously you had to omit the keys without value:

```
{
    "serial": "1",
    "status": "stored",
    "device_type": 1
}
```

fixes #60