### PR TITLE
add tab to show assets that are located at site, location or rack

### DIFF
--- a/netbox_inventory/forms/filters.py
+++ b/netbox_inventory/forms/filters.py
@@ -39,6 +39,7 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
         ('Location', (
             'storage_site_id', 'storage_location_id', 'installed_site_id', 
             'installed_location_id', 'installed_rack_id', 'installed_device_id',
+            'located_site_id', 'located_location_id',
         )),
     )
 
@@ -155,6 +156,7 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
         queryset=Site.objects.all(),
         required=False,
         label='Storage site',
+        help_text="When not in use asset is stored here",
     )
     storage_location_id = DynamicModelMultipleChoiceField(
         queryset=Location.objects.all(),
@@ -164,11 +166,13 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
             'site_id': '$storage_site_id',
         },
         label='Storage location',
+        help_text="When not in use asset is stored here",
     )
     installed_site_id = DynamicModelMultipleChoiceField(
         queryset=Site.objects.all(),
         required=False,
         label='Installed at site',
+        help_text="Currently installed here",
     )
     installed_location_id = DynamicModelMultipleChoiceField(
         queryset=Location.objects.all(),
@@ -178,6 +182,7 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
             'site_id': '$installed_site_id',
         },
         label='Installed at location',
+        help_text="Currently installed here",
     )
     installed_rack_id = DynamicModelMultipleChoiceField(
         queryset=Rack.objects.all(),
@@ -188,6 +193,7 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
             'location_id': '$installed_location_id',
         },
         label='Installed in rack',
+        help_text="Currently installed here",
     )
     installed_device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
@@ -199,6 +205,22 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
             'rack_id': '$installed_rack_id',
         },
         label='Installed in device',
+    )
+    located_site_id = DynamicModelMultipleChoiceField(
+        queryset=Site.objects.all(),
+        required=False,
+        label='Located at site',
+        help_text="Currently installed or stored here",
+    )
+    located_location_id = DynamicModelMultipleChoiceField(
+        queryset=Location.objects.all(),
+        required=False,
+        null_option='None',
+        query_params={
+            'site_id': '$located_site_id',
+        },
+        label='Located at location',
+        help_text="Currently installed or stored here",
     )
     tag = TagFilterField(model)
 

--- a/netbox_inventory/templates/netbox_inventory/tabs/located_assets_base.html
+++ b/netbox_inventory/templates/netbox_inventory/tabs/located_assets_base.html
@@ -1,0 +1,59 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load render_table from django_tables2 %}
+{% load perms %}
+
+
+{% block content %}
+
+    {% block asset_controls %}
+    <div class="controls">
+        <div class="control-group">
+            <a href="{% url 'plugins:netbox_inventory:asset_list' %}" class="btn btn-sm btn-primary">
+                <i class="mdi mdi-format-list-checkbox"></i> View Asset List
+            </a>
+            <div class="btn-group btn-group-sm" role="group">
+            </div>
+        </div>
+    </div>
+    {% endblock %}
+
+    {% include 'inc/table_controls_htmx.html' with table_modal="AssetTable_config" %}
+
+    <form method="post">
+        {% csrf_token %}
+        <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+
+        <div class="card">
+            <div class="card-body" id="object_list">
+                {% include 'htmx/table.html' %}
+            </div>
+        </div>
+
+        {% if perms.netbox_inventory.change_asset or perms.netbox_inventory.delete_asset %}
+             {% with bulk_edit_url="plugins:netbox_inventory:asset_bulk_edit" bulk_delete_url="plugins:netbox_inventory:asset_bulk_delete" %}
+                 <div class="noprint bulk-buttons">
+                     <div class="bulk-button-group">
+                         {% block bulk_buttons %}{% endblock %}
+                         {% if bulk_edit_url and perms.netbox_inventory.change_asset %}
+                             <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
+                                 <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit Selected
+                             </button>
+                         {% endif %}
+                         {% if bulk_delete_url and perms.netbox_inventory.delete_asset %}
+                             <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm">
+                                 <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> Delete Selected
+                             </button>
+                         {% endif %}
+                     </div>
+                 </div>
+             {% endwith %}
+        {% endif %}
+    </form>
+
+{% endblock %}
+
+{% block modals %}
+    {{ block.super }}
+    {% table_config_form table %}
+{% endblock modals %}

--- a/netbox_inventory/templates/netbox_inventory/tabs/located_assets_location.html
+++ b/netbox_inventory/templates/netbox_inventory/tabs/located_assets_location.html
@@ -1,0 +1,17 @@
+{% extends 'netbox_inventory/tabs/located_assets_base.html' %}
+{% load helpers %}
+
+{% block asset_controls %}
+<div class="controls">
+    <div class="control-group">
+        <a href="{% url 'plugins:netbox_inventory:asset_list' %}?{% if assets_shown == 'stored' %}storage_location_id{% elif assets_shown == 'installed' %}installed_location_id{% else %}located_location_id{% endif %}={{ object.pk }}" class="btn btn-sm btn-primary">
+            <i class="mdi mdi-format-list-checkbox"></i> View Asset List
+        </a>
+        <div class="btn-group btn-group-sm" role="group">
+            <a href="{% url 'dcim:location_inventory_assets' object.pk %}{% querystring request assets_shown='all' %}" class="btn btn-outline-secondary{% if assets_shown == 'all' %} active{% endif %}">All</a>
+            <a href="{% url 'dcim:location_inventory_assets' object.pk %}{% querystring request assets_shown='installed' %}" class="btn btn-outline-secondary{% if assets_shown == 'installed' %} active{% endif %}">Installed</a>
+            <a href="{% url 'dcim:location_inventory_assets' object.pk %}{% querystring request assets_shown='stored' %}" class="btn btn-outline-secondary{% if assets_shown == 'stored' %} active{% endif %}">Stored</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_inventory/templates/netbox_inventory/tabs/located_assets_rack.html
+++ b/netbox_inventory/templates/netbox_inventory/tabs/located_assets_rack.html
@@ -1,0 +1,17 @@
+{% extends 'netbox_inventory/tabs/located_assets_base.html' %}
+{% load helpers %}
+
+{% block asset_controls %}
+<div class="controls">
+    <div class="control-group">
+        <a href="{% url 'plugins:netbox_inventory:asset_list' %}?installed_rack_id={{ object.pk }}" class="btn btn-sm btn-primary">
+            <i class="mdi mdi-format-list-checkbox"></i> View Asset List
+        </a>
+        <div class="btn-group btn-group-sm" role="group">
+            <a href="{% url 'dcim:rack_inventory_assets' object.pk %}{% querystring request assets_shown='all' %}" class="btn btn-outline-secondary{% if assets_shown == 'all' %} active{% endif %}">All</a>
+            <a href="{% url 'dcim:rack_inventory_assets' object.pk %}{% querystring request assets_shown='installed' %}" class="btn btn-outline-secondary{% if assets_shown == 'installed' %} active{% endif %}">Installed</a>
+            <a href="{% url 'dcim:rack_inventory_assets' object.pk %}{% querystring request assets_shown='stored' %}" class="btn btn-outline-secondary{% if assets_shown == 'stored' %} active{% endif %}">Stored</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_inventory/templates/netbox_inventory/tabs/located_assets_site.html
+++ b/netbox_inventory/templates/netbox_inventory/tabs/located_assets_site.html
@@ -1,0 +1,17 @@
+{% extends 'netbox_inventory/tabs/located_assets_base.html' %}
+{% load helpers %}
+
+{% block asset_controls %}
+<div class="controls">
+    <div class="control-group">
+        <a href="{% url 'plugins:netbox_inventory:asset_list' %}?{% if assets_shown == 'stored' %}storage_site_id{% elif assets_shown == 'installed' %}installed_site_id{% else %}located_site_id{% endif %}={{ object.pk }}" class="btn btn-sm btn-primary">
+            <i class="mdi mdi-format-list-checkbox"></i> View Asset List
+        </a>
+        <div class="btn-group btn-group-sm" role="group">
+            <a href="{% url 'dcim:site_inventory_assets' object.pk %}{% querystring request assets_shown='all' %}" class="btn btn-outline-secondary{% if assets_shown == 'all' %} active{% endif %}">All</a>
+            <a href="{% url 'dcim:site_inventory_assets' object.pk %}{% querystring request assets_shown='installed' %}" class="btn btn-outline-secondary{% if assets_shown == 'installed' %} active{% endif %}">Installed</a>
+            <a href="{% url 'dcim:site_inventory_assets' object.pk %}{% querystring request assets_shown='stored' %}" class="btn btn-outline-secondary{% if assets_shown == 'stored' %} active{% endif %}">Stored</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_inventory/views/__init__.py
+++ b/netbox_inventory/views/__init__.py
@@ -5,3 +5,4 @@ from .supplier import *
 from .purchase import *
 from .asset_create import *
 from .asset_assign import *
+from .tabs import *

--- a/netbox_inventory/views/tabs.py
+++ b/netbox_inventory/views/tabs.py
@@ -1,0 +1,59 @@
+from dcim.models import Site, Location, Rack
+from netbox.views import generic
+from utilities.views import ViewTab, register_model_view
+
+from ..models import Asset
+from ..tables import AssetTable
+from ..filtersets import AssetFilterSet
+from ..utils import query_located
+
+
+class BaseAssetsTab(generic.ObjectChildrenView):
+    """
+    Shows Assets tab with table of assets located here
+    Can be filtered on installed or stored assets or both.
+    Accepts query param assets_shown:
+    - stored - show currently stored here (storage_location & stored status)
+    - installed - show currently in use here (installed as a or into a device)
+    - all - show both
+    """
+    child_model = Asset
+    table = AssetTable
+    filterset = AssetFilterSet
+    tab = ViewTab(
+        label='Assets',
+        permission='netbox_inventory.view_asset'
+    )
+
+    def get_children(self, request, parent):
+        """ Returns queryset that populates the table """
+        assets_shown = request.GET.get('assets_shown', 'all')
+        typ = parent._meta.model.__name__.lower()
+        return query_located(
+            Asset.objects.all(),
+            typ,
+            [parent.pk],
+            assets_shown
+        )
+
+    def get_extra_context(self, request, instance):
+        context = super().get_extra_context(request, instance)
+        context['assets_shown'] = request.GET.get('assets_shown', 'all')
+        return context
+
+
+@register_model_view(Site, name='inventory_assets', path='assets')
+class SiteAssets(BaseAssetsTab):
+    queryset = Site.objects.all()
+    template_name = "netbox_inventory/tabs/located_assets_site.html"
+
+
+@register_model_view(Location, name='inventory_assets', path='assets')
+class LocationAssets(BaseAssetsTab):
+    queryset = Location.objects.all()
+    template_name = "netbox_inventory/tabs/located_assets_location.html"
+
+@register_model_view(Rack, name='inventory_assets', path='assets')
+class LocationAssets(BaseAssetsTab):
+    queryset = Rack.objects.all()
+    template_name = "netbox_inventory/tabs/located_assets_rack.html"


### PR DESCRIPTION
On Site, Location and Rack details there is a new tab called Assets.

It will show in a table all assets that are at that place (location or site or rack). There are buttons to show only assets that:
- are installed there (as a device or a module or inventory item that belongs to a device at that place).
- are stored there (that has storage_location set to that location and is currently stored)
- both

Adds new filters to Asset filterset: located_site_id and located_location_id. These return all assets at a given place be it installed or currently stored.

Tabs feature is implemented using the netbox 3.4 feature where plugins can inject [additional tabs](https://docs.netbox.dev/en/stable/plugins/development/views/#additional-tabs) into objects detail view.