### PR TITLE
Show count of related assets throughout netbox

### DIFF
--- a/netbox_inventory/template_content.py
+++ b/netbox_inventory/template_content.py
@@ -14,6 +14,22 @@ class AssetInfoExtension(PluginTemplateExtension):
         return self.render('netbox_inventory/inc/asset_info.html', extra_context=context)
 
 
+class AssetTypeStats(PluginTemplateExtension):
+    def right_page(self):
+        object = self.context.get('object')
+        user = self.context['request'].user
+        context = {
+            'asset_stats': [
+                {
+                    'label': 'Total',
+                    'filter_field': f'{self.kind}_id',
+                    'count': Asset.objects.restrict(user, 'view').filter(**{self.kind:object}).count(),
+                },
+            ],
+        }
+        return self.render('netbox_inventory/inc/asset_stats_counts.html', extra_context=context)
+
+
 class DeviceAssetInfo(AssetInfoExtension):
     model = 'dcim.device'
     kind = 'device'
@@ -29,6 +45,54 @@ class InventoryItemAssetInfo(AssetInfoExtension):
     kind = 'inventoryitem'
 
 
+class DeviceTypeAssetInfo(AssetTypeStats):
+    model = 'dcim.devicetype'
+    kind = 'device_type'
+
+
+class ModuleTypeAssetInfo(AssetTypeStats):
+    model = 'dcim.moduletype'
+    kind = 'module_type'
+
+
+class ManufacturerAssetInfo(PluginTemplateExtension):
+    model = 'dcim.manufacturer'
+    def right_page(self):
+        object = self.context.get('object')
+        user = self.context['request'].user
+        count_device = Asset.objects.restrict(user, 'view').filter(device_type__manufacturer=object).count()
+        count_module = Asset.objects.restrict(user, 'view').filter(module_type__manufacturer=object).count()
+        count_inventoryitem = Asset.objects.restrict(user, 'view').filter(inventoryitem_type__manufacturer=object).count()
+        context = {
+            'asset_stats': [
+                {
+                    'label': 'Device',
+                    'filter_field': 'manufacturer_id',
+                    'extra_filter': '&kind=device',
+                    'count': count_device,
+                },
+                {
+                    'label': 'Module',
+                    'filter_field': 'manufacturer_id',
+                    'extra_filter': '&kind= module',
+                    'count': count_module,
+                },
+                {
+                    'label': 'Inventory Item',
+                    'filter_field': 'manufacturer_id',
+                    'extra_filter': '&kind=inventoryitem',
+                    'count': count_inventoryitem,
+                },
+                {
+                    'label': 'Total',
+                    'filter_field': 'manufacturer_id',
+                    'count': count_device + count_module + count_inventoryitem,
+                },
+            ],
+        }
+        return self.render('netbox_inventory/inc/asset_stats_counts.html', extra_context=context)
+
+
 class TenantAssetInfo(PluginTemplateExtension):
     model = 'tenancy.tenant'
     def right_page(self):
@@ -41,9 +105,30 @@ class TenantAssetInfo(PluginTemplateExtension):
         return self.render('netbox_inventory/inc/asset_tenant.html', extra_context=context)
 
 
+class ContactAssetInfo(PluginTemplateExtension):
+    model = 'tenancy.contact'
+    def right_page(self):
+        object = self.context.get('object')
+        user = self.context['request'].user
+        context = {
+            'asset_stats': [
+                {
+                    'label': 'Assigned',
+                    'filter_field': 'contact_id',
+                    'count': Asset.objects.restrict(user, 'view').filter(contact=object).count(),
+                },
+            ],
+        }
+        return self.render('netbox_inventory/inc/asset_stats_counts.html', extra_context=context)
+
+
 template_extensions = (
     DeviceAssetInfo,
     ModuleAssetInfo,
     InventoryItemAssetInfo,
+    DeviceTypeAssetInfo,
+    ModuleTypeAssetInfo,
+    ManufacturerAssetInfo,
     TenantAssetInfo,
+    ContactAssetInfo,
 )

--- a/netbox_inventory/template_content.py
+++ b/netbox_inventory/template_content.py
@@ -29,8 +29,21 @@ class InventoryItemAssetInfo(AssetInfoExtension):
     kind = 'inventoryitem'
 
 
+class TenantAssetInfo(PluginTemplateExtension):
+    model = 'tenancy.tenant'
+    def right_page(self):
+        object = self.context.get('object')
+        user = self.context['request'].user
+        context = {
+            'asset_assigned_count': Asset.objects.restrict(user, 'view').filter(tenant=object).count(),
+            'asset_owned_count': Asset.objects.restrict(user, 'view').filter(owner=object).count(),
+        }
+        return self.render('netbox_inventory/inc/asset_tenant.html', extra_context=context)
+
+
 template_extensions = (
     DeviceAssetInfo,
     ModuleAssetInfo,
     InventoryItemAssetInfo,
+    TenantAssetInfo,
 )

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_stats_counts.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_stats_counts.html
@@ -1,0 +1,15 @@
+{% load helpers %}
+
+<div class="card">
+  <h5 class="card-header">Assets</h5>
+  <div class="card-body">
+    <table class="table table-hover attr-table">
+    {% for asset_stat in asset_stats %}
+      <tr>
+        <td>{{ asset_stat.label }}</td>
+        <td><a href="{% url 'plugins:netbox_inventory:asset_list' %}?{{ asset_stat.filter_field }}={{ object.pk }}{{ asset_stat.extra_filter }}">{{ asset_stat.count }}</a></td>
+      </tr>
+    {% endfor %}
+    </table>
+  </div>
+</div>

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_tenant.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_tenant.html
@@ -1,0 +1,15 @@
+{% load helpers %}
+
+<div class="card">
+  <h5 class="card-header">Assets</h5>
+  <div class="row card-body">
+    <div class="col col-md-4 text-center">
+      <h2><a href="{% url 'plugins:netbox_inventory:asset_list' %}?owner_id={{ object.pk }}" class="stat-btn btn {% if asset_owned_count %}btn-primary{% else %}btn-outline-dark{% endif %} btn-lg">{{ asset_owned_count }}</a></h2>
+      <p>Owned</p>
+    </div>
+    <div class="col col-md-4 text-center">
+      <h2><a href="{% url 'plugins:netbox_inventory:asset_list' %}?tenant_id={{ object.pk }}" class="stat-btn btn {% if asset_assigned_count %}btn-primary{% else %}btn-outline-dark{% endif %} btn-lg">{{ asset_assigned_count }}</a></h2>
+      <p>Assigned</p>
+    </div>
+  </div>
+</div>

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
@@ -38,6 +38,10 @@
               <th scope="row">Group</th>
               <td>{{ object.inventoryitem_group|linkify|placeholder }}</td>
             </tr>
+            <tr>
+              <th scope="row">Assets</th>
+              <td><a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_type_id={{ object.pk }}">{{ asset_count }}</a></td>
+            </tr>
           </table>
         </div>
       </div>

--- a/netbox_inventory/views/inventoryitem_type.py
+++ b/netbox_inventory/views/inventoryitem_type.py
@@ -15,6 +15,11 @@ __all__ = (
 class InventoryItemTypeView(generic.ObjectView):
     queryset = models.InventoryItemType.objects.all()
 
+    def get_extra_context(self, request, instance):
+        context = super().get_extra_context(request, instance)
+        context['asset_count'] = models.Asset.objects.restrict(request.user, 'view').filter(inventoryitem_type=instance).count()
+        return context
+
 
 class InventoryItemTypeListView(generic.ObjectListView):
     queryset = models.InventoryItemType.objects.annotate(


### PR DESCRIPTION
On Manufacturer, Device Type, Module Type, Contact, Tenant and Inventory Item Type we shoe count of assets related to that object. And links to filtered Asset list.

closes #14 
