### PR TITLE
extend detail templates to accept content injected by other plugins

### DIFF
--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -1,6 +1,7 @@
 {% extends 'generic/object.html' %}
 {% load helpers %}
 {% load humanize %}
+{% load plugins %}
 
 {% block title %}{{ object.hardware_type.manufacturer }} {{ object }}{% endblock %}
 
@@ -141,6 +142,7 @@
         </div>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       <div class="card">
@@ -179,6 +181,12 @@
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/image_attachments.html' %}
+      {% plugin_right_page object %}
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
@@ -1,5 +1,6 @@
 {% extends 'generic/object.html' %}
 {% load helpers %}
+{% load plugins %}
 {% load render_table from django_tables2 %}
 
 {% block breadcrumbs %}
@@ -107,7 +108,7 @@
           </table>
         </div>
       </div>
-  
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       <div class="card">
@@ -127,6 +128,7 @@
       </div>
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% plugin_right_page object %}
     </div>
   </div>
   <div class="row mb-3">
@@ -138,6 +140,7 @@
           {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
         </div>
       </div>
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 
 {% block title %}{{ object.manufacturer }} {{ object.model }}{% endblock %}
 
@@ -46,11 +47,18 @@
         </div>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/image_attachments.html' %}
+      {% plugin_right_page object %}
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -1,5 +1,6 @@
 {% extends 'generic/object.html' %}
 {% load helpers %}
+{% load plugins %}
 {% load render_table from django_tables2 %}
 
 {% block breadcrumbs %}
@@ -50,10 +51,12 @@
         </div>
       </div>
       {% include 'inc/panels/tags.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% plugin_right_page object %}
     </div>
   </div>
   <div class="row mb-3">
@@ -65,6 +68,7 @@
           {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
         </div>
       </div>
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load render_table from django_tables2 %}
 
 {% block breadcrumbs %}
@@ -44,10 +45,12 @@
         </div>
       </div>
       {% include 'inc/panels/tags.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% plugin_right_page object %}
     </div>
   </div>
   <div class="row mb-3">
@@ -59,5 +62,6 @@
           {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
         </div>
       </div>
+      {% plugin_full_width_page object %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
Make use of `plugin_right_page` `plugin_left_page` and `plugin_full_width_page` so other plugins can inject content into object detail views 