### PR TITLE
Add: search support for custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ PLUGINS_CONFIG = {
 | `asset_import_create_tenant` | `False` | When importing an asset, with owner or tenant, automatically create tenant if it doesn't exist |
 | `asset_disable_editing_fields_for_tags` | `{}` | A dictionary of tags and fields that should be disabled for editing. This is useful if you want to prevent editing of certain fields for certain assets. The dictionary is in the form of `{tag: [field1, field2]}`. Example: `{'no-edit': ['serial_number', 'asset_tag']}`. This only affects the UI, the API can still be used to edit the fields. |
 | `asset_disable_deletion_for_tags` | `[]` | List of tags that will disable deletion of assets. This only affects the UI, not the API. |
+| `asset_custom_fields_search_filters` | `{}` | A dictionary of custom fields and lookup types that will be added to the search filters for assets. The dictionary is in the form of `{field: [lookup_type]}`. Example: `{'asset_mac': ['icontains', 'exact']}`. |
 | `prefill_asset_name_create_inventoryitem` | `False` | When hardware inventory item is created from an asset, prefill the InventoryItem name to match the asset name. |
 | `prefill_asset_tag_create_inventoryitem` | `False` | When hardware inventory item is created from an asset, prefill the tags to match the tags associated to the asset. |
 

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -23,6 +23,7 @@ class NetBoxInventoryConfig(PluginConfig):
         'asset_import_create_tenant': False,
         'asset_disable_editing_fields_for_tags': {},
         'asset_disable_deletion_for_tags': [],
+        'asset_custom_fields_search_filters': {},
         'prefill_asset_name_create_inventoryitem': False,
         'prefill_asset_tag_create_inventoryitem': False,
     }

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -178,3 +178,23 @@ def query_located(queryset, field_name, values, assets_shown='all'):
     else:
         raise Exception('unsupported')
     return queryset.filter(q)
+
+
+def get_asset_custom_fields_search_filters():
+    """Returns a list of custom field filter strings that can be used in Q() filter.
+
+    Custom fields and filters are used is defined in the plugin configuration,
+    under the key ``asset_custom_fields_search_filters``.
+
+    Returns:
+        list: list of custom field filter strings
+    """
+    custom_fields = settings.PLUGINS_CONFIG['netbox_inventory'][
+        'asset_custom_fields_search_filters'
+    ]
+
+    fields = []
+    for field_name, filters in custom_fields.items():
+        for filter in filters:
+            fields.append(f"custom_field_data__{field_name}__{filter}")
+    return fields

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -189,12 +189,10 @@ def get_asset_custom_fields_search_filters():
     Returns:
         list: list of custom field filter strings
     """
-    custom_fields = settings.PLUGINS_CONFIG['netbox_inventory'][
-        'asset_custom_fields_search_filters'
-    ]
+    custom_fields_filters = get_plugin_setting('asset_custom_fields_search_filters')
 
     fields = []
-    for field_name, filters in custom_fields.items():
+    for field_name, filters in custom_fields_filters.items():
         for filter in filters:
             fields.append(f"custom_field_data__{field_name}__{filter}")
     return fields


### PR DESCRIPTION
This pull request adds support for search on custom fields. It supports different lookup types which need to be specified in configuration.

Example of config:
```python
{
'asset_custom_fields_search_filters': { 'asset_mac': ['exact'], 'another_one': ['icontains', 'exact']}
}
```