### PR TITLE
Fix Asset import with Purchase & Delivery info

### DIFF
--- a/netbox_inventory/tests/asset/test_api.py
+++ b/netbox_inventory/tests/asset/test_api.py
@@ -146,7 +146,7 @@ class AssetTest(
         cls.device1 = Device.objects.create(name='Device 1', device_role=device_role1, device_type=device_type1, site=site1, status='active')
         cls.device2 = Device.objects.create(name='Device 2', device_role=device_role1, device_type=device_type2, site=site1, status='active')
         cls.inventoryitem1 = InventoryItem.objects.create(device=cls.device1, name='II 1')
-        supplier1 = Supplier.objects.create(name='Supplier1')
+        supplier1 = Supplier.objects.create(name='Supplier1', slug='supplier1')
         cls.purchase1 = Purchase.objects.create(name='Purchase1', supplier=supplier1)
         cls.delivery1 = Delivery.objects.create(name='Delivery1', purchase=cls.purchase1)
 

--- a/netbox_inventory/tests/asset/test_models.py
+++ b/netbox_inventory/tests/asset/test_models.py
@@ -11,6 +11,7 @@ class TestAssetModel(TestCase):
     def setUp(self):
         self.supplier1 = Supplier.objects.create(
             name='Supplier1',
+            slug='supplier1',
         )
         self.purchase1 = Purchase.objects.create(
             name='Purchase1',

--- a/netbox_inventory/tests/asset/test_views.py
+++ b/netbox_inventory/tests/asset/test_views.py
@@ -21,6 +21,7 @@ class AssetTestCase(
     def setUpTestData(cls):
         supplier1 = Supplier.objects.create(
             name='Supplier1',
+            slug='supplier1',
         )
         purchase1 = Purchase.objects.create(
             name='Purchase1',
@@ -161,6 +162,7 @@ class AssetTestCase(
 
         supplier1 = Supplier.objects.create(
             name='Supplier1-autoset',
+            slug='supplier1-autoset',
         )
         purchase1 = Purchase.objects.create(
             name='Purchase1-autoset',

--- a/netbox_inventory/tests/asset/test_views.py
+++ b/netbox_inventory/tests/asset/test_views.py
@@ -19,6 +19,25 @@ class AssetTestCase(
 
     @classmethod
     def setUpTestData(cls):
+        supplier1 = Supplier.objects.create(
+            name='Supplier1',
+        )
+        purchase1 = Purchase.objects.create(
+            name='Purchase1',
+            supplier=supplier1,
+        )
+        purchase2 = Purchase.objects.create(
+            name='Purchase2',
+            supplier=supplier1,
+        )
+        delivery1 = Delivery.objects.create(
+            name='the_delivery',
+            purchase=purchase1,
+        )
+        delivery2 = Delivery.objects.create(
+            name='the_delivery',
+            purchase=purchase2,
+        )
         site1 = Site.objects.create(
             name='site1',
             slug='site1',
@@ -61,10 +80,10 @@ class AssetTestCase(
             'device_type': device_type1.pk,
         }
         cls.csv_data = (
-            'serial,status,hardware_kind,manufacturer,model_name',
-            'csv1,stored,device,manufacturer1,device_type1',
-            'csv2,stored,device,manufacturer1,device_type1',
-            'csv3,stored,device,manufacturer_csv,device_type_csv',
+            'serial,status,hardware_kind,manufacturer,model_name,supplier,purchase,delivery',
+            'csv1,stored,device,manufacturer1,device_type1,Supplier1,Purchase1,the_delivery',
+            'csv2,stored,device,manufacturer1,device_type1,Supplier1,Purchase1,the_delivery',
+            'csv3,stored,device,manufacturer_csv,device_type_csv,,,',
         )
         cls.csv_update_data = (
             'id,serial,status',
@@ -141,14 +160,14 @@ class AssetTestCase(
         obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
         supplier1 = Supplier.objects.create(
-            name='Supplier1',
+            name='Supplier1-autoset',
         )
         purchase1 = Purchase.objects.create(
-            name='Purchase1',
+            name='Purchase1-autoset',
             supplier=supplier1,
         )
         delivery1 = Delivery.objects.create(
-            name='Delivery1',
+            name='Delivery1-autoset',
             purchase=purchase1,
         )
 


### PR DESCRIPTION
If you had multiple Purchases with the same name but different Suppliers or multiple Deliveries with same name but from different Purchases, the CSV import failed because it searched only on name.

I replaced `CSVModelChoiceField` with `CharFields` and am getting the correct Purchase & Delivery instances in `AssetImportForm.clean_<field>` methods, where I have access to all columns.
