### PR TITLE
use htmx to include asset table on detail views

### DIFF
--- a/netbox_inventory/templates/netbox_inventory/delivery.html
+++ b/netbox_inventory/templates/netbox_inventory/delivery.html
@@ -13,14 +13,6 @@
   </li>
 {% endblock %}
 
-{% block extra_controls %}
-  {% if perms.netbox_inventory.add_asset %}
-    <a href="{% url 'plugins:netbox_inventory:asset_add' %}?delivery={{ object.pk }}" class="btn btn-sm btn-primary">
-      <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add asset
-    </a>
-  {% endif %}
-{% endblock extra_controls %}
-
 {% block content %}
   <div class="row mb-3">
     <div class="col col-md-6">
@@ -70,10 +62,17 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Delivered Assets</h5>
-        <div class="card-body table-responsive">
-          {% render_table asset_table 'inc/table.html' %}
-          {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
-        </div>
+        <div class="card-body htmx-container table-responsive"
+          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?delivery_id={{ object.pk }}"
+          hx-trigger="load"
+        ></div>
+        {% if perms.netbox_inventory.add_asset %}
+          <div class="card-footer text-end noprint">
+            <a href="{% url 'plugins:netbox_inventory:asset_add' %}?delivery={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+              <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
+            </a>
+          </div>
+        {% endif %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -10,14 +10,6 @@
   </li>
 {% endblock %}
 
-{% block extra_controls %}
-  {% if perms.netbox_inventory.add_asset %}
-    <a href="{% url 'plugins:netbox_inventory:asset_add' %}?purchase={{ object.pk }}" class="btn btn-sm btn-primary">
-      <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add asset
-    </a>
-  {% endif %}
-{% endblock extra_controls %}
-
 {% block content %}
   <div class="row mb-3">
     <div class="col col-md-6">
@@ -83,10 +75,17 @@
       </div>
       <div class="card">
         <h5 class="card-header">Purchased Assets</h5>
-        <div class="card-body table-responsive">
-          {% render_table asset_table 'inc/table.html' %}
-          {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
-        </div>
+        <div class="card-body htmx-container table-responsive"
+          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?purchase_id={{ object.pk }}"
+          hx-trigger="load"
+        ></div>
+        {% if perms.netbox_inventory.add_asset %}
+          <div class="card-footer text-end noprint">
+            <a href="{% url 'plugins:netbox_inventory:asset_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+              <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
+            </a>
+          </div>
+        {% endif %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -16,11 +16,6 @@
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add asset
     </a>
   {% endif %}
-  {% if perms.netbox_inventory.add_delivery %}
-    <a href="{% url 'plugins:netbox_inventory:delivery_add' %}?purchase={{ object.pk }}" class="btn btn-sm btn-primary">
-      <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add delivery
-    </a>
-  {% endif %}
 {% endblock extra_controls %}
 
 {% block content %}
@@ -78,6 +73,13 @@
           hx-get="{% url 'plugins:netbox_inventory:delivery_list' %}?purchase_id={{ object.pk }}"
           hx-trigger="load"
         ></div>
+        {% if perms.netbox_inventory.add_delivery %}
+          <div class="card-footer text-end noprint">
+            <a href="{% url 'plugins:netbox_inventory:delivery_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+              <i class="mdi mdi-plus-thick" aria-hidden="true"></i>Add a Delivery
+            </a>
+          </div>
+        {% endif %}
       </div>
       <div class="card">
         <h5 class="card-header">Purchased Assets</h5>

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -74,10 +74,10 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Deliveries</h5>
-        <div class="card-body table-responsive">
-          {% render_table delivery_table 'inc/table.html' %}
-          {% include 'inc/paginator.html' with paginator=delivery_table.paginator page=delivery_table.page %}
-        </div>
+        <div class="card-body htmx-container table-responsive"
+          hx-get="{% url 'plugins:netbox_inventory:delivery_list' %}?purchase_id={{ object.pk }}"
+          hx-trigger="load"
+        ></div>
       </div>
       <div class="card">
         <h5 class="card-header">Purchased Assets</h5>

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -63,10 +63,10 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Supplied Assets</h5>
-        <div class="card-body table-responsive">
-          {% render_table asset_table 'inc/table.html' %}
-          {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
-        </div>
+        <div class="card-body htmx-container table-responsive"
+          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?supplier_id={{ object.pk }}"
+          hx-trigger="load"
+        ></div>
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/views/delivery.py
+++ b/netbox_inventory/views/delivery.py
@@ -16,19 +16,7 @@ class DeliveryView(generic.ObjectView):
     queryset = models.Delivery.objects.all()
 
     def get_extra_context(self, request, instance):
-        delivery_assets = models.Asset.objects.restrict(request.user, 'view').filter(
-            delivery=instance
-        )
-        asset_table = tables.AssetTable(delivery_assets, user=request.user)
-        asset_table.columns.hide('delivery')
-        asset_table.columns.hide('delivery_date')
-        asset_table.columns.hide('purchase')
-        asset_table.columns.hide('purchase_date')
-        asset_table.columns.hide('supplier')
-        asset_table.configure(request)
-
         return {
-            'asset_table': asset_table,
             'asset_count': models.Asset.objects.filter(delivery=instance).count(),
         }
 

--- a/netbox_inventory/views/purchase.py
+++ b/netbox_inventory/views/purchase.py
@@ -16,17 +16,7 @@ class PurchaseView(generic.ObjectView):
     queryset = models.Purchase.objects.all()
 
     def get_extra_context(self, request, instance):
-        purchase_assets = models.Asset.objects.restrict(request.user, 'view').filter(
-            purchase=instance
-        )
-        asset_table = tables.AssetTable(purchase_assets, user=request.user)
-        asset_table.columns.hide('purchase')
-        asset_table.columns.hide('purchase_date')
-        asset_table.columns.hide('supplier')
-        asset_table.configure(request)
-
         return {
-            'asset_table': asset_table,
             'asset_count': models.Asset.objects.filter(purchase=instance).count(),
             'delivery_count': models.Delivery.objects.filter(purchase=instance).count(),
         }

--- a/netbox_inventory/views/purchase.py
+++ b/netbox_inventory/views/purchase.py
@@ -16,19 +16,9 @@ class PurchaseView(generic.ObjectView):
     queryset = models.Purchase.objects.all()
 
     def get_extra_context(self, request, instance):
-        purchase_deliveries = models.Delivery.objects.restrict(request.user, 'view').filter(
-            purchase=instance
-        )
         purchase_assets = models.Asset.objects.restrict(request.user, 'view').filter(
             purchase=instance
         )
-
-        delivery_table = tables.DeliveryTable(purchase_deliveries, user=request.user)
-        delivery_table.columns.hide('purchase')
-        delivery_table.columns.hide('purchase_date')
-        delivery_table.columns.hide('supplier')
-        delivery_table.configure(request)
-
         asset_table = tables.AssetTable(purchase_assets, user=request.user)
         asset_table.columns.hide('purchase')
         asset_table.columns.hide('purchase_date')
@@ -38,7 +28,6 @@ class PurchaseView(generic.ObjectView):
         return {
             'asset_table': asset_table,
             'asset_count': models.Asset.objects.filter(purchase=instance).count(),
-            'delivery_table': delivery_table,
             'delivery_count': models.Delivery.objects.filter(purchase=instance).count(),
         }
 

--- a/netbox_inventory/views/supplier.py
+++ b/netbox_inventory/views/supplier.py
@@ -20,15 +20,7 @@ class SupplierView(generic.ObjectView):
     queryset = models.Supplier.objects.all()
 
     def get_extra_context(self, request, instance):
-        supplier_assets = models.Asset.objects.restrict(request.user, 'view').filter(
-            purchase__supplier=instance
-        )
-        asset_table = tables.AssetTable(supplier_assets, user=request.user)
-        asset_table.columns.hide('supplier')
-        asset_table.configure(request)
-
         return {
-            'asset_table': asset_table,
             'asset_count': models.Asset.objects.filter(purchase__supplier=instance).count(),
             'purchase_count': models.Purchase.objects.filter(supplier=instance).count(),
             'delivery_count': models.Delivery.objects.filter(purchase__supplier=instance).count(),


### PR DESCRIPTION
Instead of creating tables in view and rendering in template, we include tables using HTMX. Initial page load will be faster since additional tables load in background.

This is what core netbox moved to in most detail views.

also fixes #126 