### PR TITLE
Remove CF from assign/reassign forms

### DIFF
--- a/netbox_inventory/forms/assign.py
+++ b/netbox_inventory/forms/assign.py
@@ -66,6 +66,11 @@ class AssetAssignMixin(forms.Form):
         # remove tags field from form
         self.fields.pop('tags')
 
+        # Remove Custom Fields from form
+        for cf_name in self.custom_fields.keys():
+           self.fields.pop(cf_name, None)
+        self.custom_fields = {}
+        self.custom_fields_groups = {}
 
 class AssetDeviceAssignForm(AssetAssignMixin, NetBoxModelForm):
     site = DynamicModelChoiceField(

--- a/netbox_inventory/forms/reassign.py
+++ b/netbox_inventory/forms/reassign.py
@@ -103,6 +103,12 @@ class AssetReassignMixin(forms.Form):
         # remove tags field from form
         self.fields.pop('tags')
 
+        # Remove Custom Fields from form
+        for cf_name in self.custom_fields.keys():
+           self.fields.pop(cf_name, None)
+        self.custom_fields = {}
+        self.custom_fields_groups = {}
+
         try:
             self.instance.assigned_asset
         except Asset.DoesNotExist:


### PR DESCRIPTION
- Solves #120 
- Clear any custom fields while assigning/reassigning `Asset` to models that inherit from `AssetAssignMixin`/`AssetReassignMixin`