### PR TITLE
fix assigning asset to inventory item when inventory item type model …

### DIFF
--- a/netbox_inventory/forms/create.py
+++ b/netbox_inventory/forms/create.py
@@ -107,7 +107,7 @@ class AssetInventoryItemCreateForm(AssetCreateMixin, InventoryItemForm):
             self.fields['manufacturer'].disabled = True
             self.initial['serial'] = asset.serial
             self.initial['asset_tag'] = asset.asset_tag if asset.asset_tag else None
-            self.initial['part_id'] = asset.inventoryitem_type.part_number or asset.inventoryitem_type.model
+            self.initial['part_id'] = asset.inventoryitem_type.part_number
             self.initial['manufacturer'] = asset.inventoryitem_type.manufacturer_id
 
             if get_plugin_setting('prefill_asset_name_create_inventoryitem'):

--- a/netbox_inventory/tests/asset/test_views_reassign.py
+++ b/netbox_inventory/tests/asset/test_views_reassign.py
@@ -51,11 +51,13 @@ class AssetReassignBase():
         self.inventoryitem_type1 = InventoryItemType.objects.create(
             manufacturer=self.manufacturer1,
             model='inventoryitem_type1',
+            part_number='partnumber1',
             slug='inventoryitem_type1'
         )
         self.inventoryitem_type2 = InventoryItemType.objects.create(
             manufacturer=self.manufacturer1,
             model='inventoryitem_type2',
+            part_number='partnumber2',
             slug='inventoryitem_type2'
         )
         self.device1 = Device.objects.create(
@@ -246,7 +248,7 @@ class InventoryItemReassignAssetTestCase(AssetReassignBase, ModelViewTestCase):
         self.tested_hardware.refresh_from_db()
         self.asset_new.refresh_from_db()
         self.assertEqual(self.tested_hardware.manufacturer, self.asset_new.inventoryitem_type.manufacturer)
-        self.assertEqual(self.tested_hardware.part_id, self.asset_new.inventoryitem_type.model)
+        self.assertEqual(self.tested_hardware.part_id, self.asset_new.inventoryitem_type.part_number)
 
 
 class DeviceUnassignAssetTestCase(AssetReassignBase, ModelViewTestCase):
@@ -305,4 +307,4 @@ class InventoryItemUnassignAssetTestCase(AssetReassignBase, ModelViewTestCase):
         # also check if inventory item manufacturer and part_id was kept
         self.tested_hardware.refresh_from_db()
         self.assertEqual(self.tested_hardware.manufacturer, self.asset_old.inventoryitem_type.manufacturer)
-        self.assertEqual(self.tested_hardware.part_id, self.asset_old.inventoryitem_type.model)
+        self.assertEqual(self.tested_hardware.part_id, self.asset_old.inventoryitem_type.part_number)

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -108,7 +108,7 @@ def asset_set_new_hw(asset, hw):
         if hw.manufacturer != asset.inventoryitem_type.manufacturer:
             hw.manufacturer = asset.inventoryitem_type.manufacturer
             hw_save = True
-        part_id = asset.inventoryitem_type.part_number or asset.inventoryitem_type.model
+        part_id = asset.inventoryitem_type.part_number
         if hw.part_id != part_id:
             hw.part_id = part_id
             hw_save = True


### PR DESCRIPTION
…name is very long

we now only sync `asset.inventoryitem_type.part_number` to `inventoryitem.part_id`. We never use `asset.inventoryitem_type.model` in `inventoryitem` fields.

fixes #132
