### PR TITLE
Arrange menu items

### DIFF
--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -16,13 +16,15 @@ asset_buttons = [
         link='plugins:netbox_inventory:asset_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_asset"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:asset_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_asset"],
     )
 ]
 
@@ -31,13 +33,15 @@ supplier_buttons = [
         link='plugins:netbox_inventory:supplier_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_supplier"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:supplier_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_supplier"],
     )
 ]
 
@@ -46,13 +50,15 @@ purchase_buttons = [
         link='plugins:netbox_inventory:purchase_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_purchase"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:purchase_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_purchase"],
     )
 ]
 
@@ -61,13 +67,15 @@ delivery_buttons = [
         link='plugins:netbox_inventory:delivery_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_delivery"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:delivery_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_delivery"],
     )
 ]
 
@@ -76,13 +84,15 @@ inventoryitemtype_buttons = [
         link='plugins:netbox_inventory:inventoryitemtype_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_inventoryitemtype"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:inventoryitemtype_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_inventoryitemtype"],
     )
 ]
 
@@ -91,13 +101,15 @@ inventoryitemgroup_buttons = [
         link='plugins:netbox_inventory:inventoryitemgroup_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
+        color=ButtonColorChoices.GREEN,
+        permissions=["netbox_inventory.add_inventoryitemgroup"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:inventoryitemgroup_import',
         title='Import',
         icon_class='mdi mdi-upload',
         color=ButtonColorChoices.CYAN,
+        permissions=["netbox_inventory.add_inventoryitemgroup"],
     )
 ]
 

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -103,13 +103,28 @@ inventoryitemgroup_buttons = [
     )
 ]
 
-menu_buttons = (
+assets_buttons = (
     PluginMenuItem(
         link='plugins:netbox_inventory:asset_list',
         link_text='Assets',
         permissions=["netbox_inventory.view_asset"],
         buttons=asset_buttons,
     ),
+    PluginMenuItem(
+        link='plugins:netbox_inventory:inventoryitemtype_list',
+        link_text='Inventory Item Types',
+        permissions=["netbox_inventory.view_inventoryitemtype"],
+        buttons=inventoryitemtype_buttons,
+    ),
+    PluginMenuItem(
+        link='plugins:netbox_inventory:inventoryitemgroup_list',
+        link_text='Inventory Item Groups',
+        permissions=["netbox_inventory.view_inventoryitemgroup"],
+        buttons=inventoryitemgroup_buttons,
+    ),
+)
+
+deliveries_buttons = (
     PluginMenuItem(
         link='plugins:netbox_inventory:supplier_list',
         link_text='Suppliers',
@@ -128,18 +143,6 @@ menu_buttons = (
         permissions=["netbox_inventory.view_delivery"],
         buttons=delivery_buttons,
     ),
-    PluginMenuItem(
-        link='plugins:netbox_inventory:inventoryitemtype_list',
-        link_text='Inventory Item Types',
-        permissions=["netbox_inventory.view_inventoryitemtype"],
-        buttons=inventoryitemtype_buttons,
-    ),
-    PluginMenuItem(
-        link='plugins:netbox_inventory:inventoryitemgroup_list',
-        link_text='Inventory Item Groups',
-        permissions=["netbox_inventory.view_inventoryitemgroup"],
-        buttons=inventoryitemgroup_buttons,
-    ),
 )
 
 # can't use utils.get_plugin_setting() here, get value manually
@@ -148,7 +151,8 @@ if (HAVE_MENU and settings.PLUGINS_CONFIG['netbox_inventory']['top_level_menu'])
     menu = PluginMenu(
         label=f'Inventory',
         groups=(
-            ('Asset Management', menu_buttons),
+            ('Asset Management', assets_buttons),
+            ('Deliveries', deliveries_buttons),
         ),
         icon_class='mdi mdi-clipboard-text-multiple-outline'
     )

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -156,4 +156,4 @@ if (HAVE_MENU and settings.PLUGINS_CONFIG['netbox_inventory']['top_level_menu'])
     )
 else:
     # display under plugins
-    menu_items = menu_buttons
+    menu_items = assets_buttons + deliveries_buttons

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,5 +1,3 @@
-from packaging import version
-
 from django.conf import settings
 from extras.plugins import PluginMenuItem, PluginMenuButton
 from utilities.choices import ButtonColorChoices


### PR DESCRIPTION
The Netbox Inventory plugin serves two purposes: It manages assets and it manages the process around deliveries. Now they are separated in the menu for easier navigation.
