### PR TITLE
Netbox 4 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        netbox-version: ["v3.7.5"]
+        netbox-version: ["v4.0.0"]
     services:
       redis:
         image: redis

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -1,4 +1,4 @@
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 from .version import __version__
 
 

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -10,7 +10,7 @@ class NetBoxInventoryConfig(PluginConfig):
     author = 'Matej Vadnjal'
     author_email = 'matej.vadnjal@arnes.si'
     base_url = 'inventory'
-    min_version = '3.7.0'
+    min_version = '4.0.0'
     default_settings = {
         'top_level_menu': True,
         'used_status_name': 'used',

--- a/netbox_inventory/api/nested_serializers.py
+++ b/netbox_inventory/api/nested_serializers.py
@@ -1,69 +1,11 @@
 from rest_framework import serializers
 
-from dcim.api.serializers import NestedManufacturerSerializer
 from netbox.api.serializers import WritableNestedSerializer
-from ..models import Asset, Delivery, InventoryItemType, InventoryItemGroup, Purchase, Supplier
+from ..models import InventoryItemGroup
 
 __all__ = (
-    'NestedAssetSerializer',
-    'NestedSupplierSerializer',
-    'NestedPurchaseSerializer',
-    'NestedDeliverySerializer',
-    'NestedInventoryItemTypeSerializer',
     'NestedInventoryItemGroupSerializer',
 )
-
-
-class NestedAssetSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:asset-detail'
-    )
-
-    class Meta:
-        model = Asset
-        fields = ('id', 'url', 'display', 'serial')
-
-
-class NestedSupplierSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:supplier-detail'
-    )
-
-    class Meta:
-        model = Supplier
-        fields = ('id', 'url', 'display', 'name', 'slug')
-
-
-class NestedPurchaseSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:purchase-detail'
-    )
-    supplier = NestedSupplierSerializer(read_only=True)
-
-    class Meta:
-        model = Purchase
-        fields = ('id', 'url', 'display', 'supplier', 'name', 'status', 'date')
-
-
-class NestedDeliverySerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:delivery-detail'
-    )
-
-    class Meta:
-        model = Delivery
-        fields = ('id', 'url', 'display', 'name', 'date')
-
-
-class NestedInventoryItemTypeSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:inventoryitemtype-detail'
-    )
-    manufacturer = NestedManufacturerSerializer(read_only=True)
-
-    class Meta:
-        model = InventoryItemType
-        fields = ('id', 'url', 'display', 'manufacturer', 'model', 'slug')
 
 
 class NestedInventoryItemGroupSerializer(WritableNestedSerializer):

--- a/netbox_inventory/api/serializers.py
+++ b/netbox_inventory/api/serializers.py
@@ -1,33 +1,119 @@
 from rest_framework import serializers
 
 from dcim.api.serializers import (
-    NestedDeviceTypeSerializer, NestedDeviceSerializer,
-    NestedManufacturerSerializer,
-    NestedModuleTypeSerializer, NestedModuleSerializer,
-    NestedInventoryItemSerializer, NestedLocationSerializer
+    DeviceTypeSerializer, DeviceSerializer, ManufacturerSerializer,
+    ModuleTypeSerializer, ModuleSerializer, InventoryItemSerializer,
+    LocationSerializer
 )
-from tenancy.api.serializers import NestedContactSerializer, NestedTenantSerializer
-from netbox.api.serializers import NetBoxModelSerializer
+from tenancy.api.serializers import ContactSerializer, TenantSerializer
+from netbox.api.serializers import NestedGroupModelSerializer, NetBoxModelSerializer
 from .nested_serializers import *
 from ..models import Asset, Delivery, InventoryItemType, InventoryItemGroup, Purchase, Supplier
+
+
+class SupplierSerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='plugins-api:netbox_inventory-api:supplier-detail'
+    )
+    asset_count = serializers.IntegerField(read_only=True)
+    purchase_count = serializers.IntegerField(read_only=True)
+    delivery_count = serializers.IntegerField(read_only=True)
+    
+    class Meta:
+        model = Supplier
+        fields = (
+            'id', 'url', 'display', 'name', 'slug', 'description', 'comments',
+            'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
+            'purchase_count', 'delivery_count',
+        )
+        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+
+
+class PurchaseSerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='plugins-api:netbox_inventory-api:purchase-detail'
+    )
+    supplier = SupplierSerializer(nested=True)
+    asset_count = serializers.IntegerField(read_only=True)
+    delivery_count = serializers.IntegerField(read_only=True)
+    
+    class Meta:
+        model = Purchase
+        fields = (
+            'id', 'url', 'display', 'supplier', 'name', 'status', 'date', 'description',
+            'comments', 'tags', 'custom_fields', 'created', 'last_updated',
+            'asset_count', 'delivery_count',
+        )
+        brief_fields = ('id', 'url', 'display', 'supplier', 'name', 'status', 'date')
+
+
+class DeliverySerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='plugins-api:netbox_inventory-api:delivery-detail'
+    )
+    purchase = PurchaseSerializer(nested=True)
+    receiving_contact = ContactSerializer(nested=True, required=False, allow_null=True, default=None)
+    asset_count = serializers.IntegerField(read_only=True)
+    
+    class Meta:
+        model = Delivery
+        fields = (
+            'id', 'url', 'display', 'purchase', 'name', 'date', 'description', 'comments',
+            'receiving_contact', 'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
+        )
+        brief_fields = ('id', 'url', 'display', 'name', 'date')
+
+
+class InventoryItemGroupSerializer(NestedGroupModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='plugins-api:netbox_inventory-api:inventoryitemgroup-detail'
+    )
+    parent = NestedInventoryItemGroupSerializer(required=False, allow_null=True, default=None)
+    asset_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = InventoryItemGroup
+        fields = (
+            'id', 'url', 'display', 'name', 'parent', 'comments', 'tags', 'custom_fields',
+            'created', 'last_updated', 'asset_count', '_depth',
+        )
+        brief_fields = ('id', 'url', 'display', 'name', '_depth')
+
+
+class InventoryItemTypeSerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='plugins-api:netbox_inventory-api:inventoryitemtype-detail'
+    )
+    manufacturer = ManufacturerSerializer(nested=True)
+    inventoryitem_group = InventoryItemGroupSerializer(nested=True, required=False, allow_null=True, default=None)
+    asset_count = serializers.IntegerField(read_only=True)
+    
+    class Meta:
+        model = InventoryItemType
+        fields = (
+            'id', 'url', 'display', 'model', 'slug', 'manufacturer', 'part_number',
+            'inventoryitem_group', 'comments', 'tags', 'custom_fields', 'created',
+            'last_updated', 'asset_count',
+        )
+        brief_fields = ('id', 'url', 'display', 'manufacturer', 'model', 'slug')
 
 
 class AssetSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_inventory-api:asset-detail'
     )
-    device_type = NestedDeviceTypeSerializer(required=False, allow_null=True, default=None)
-    device = NestedDeviceSerializer(required=False, allow_null=True, default=None)
-    module_type = NestedModuleTypeSerializer(required=False, allow_null=True, default=None)
-    module = NestedModuleSerializer(required=False, allow_null=True, default=None)
-    inventoryitem_type = NestedInventoryItemTypeSerializer(required=False, allow_null=True, default=None) 
-    inventoryitem = NestedInventoryItemSerializer(required=False, allow_null=True, default=None)
-    storage_location = NestedLocationSerializer(required=False, allow_null=True, default=None)
-    delivery = NestedDeliverySerializer(required=False, allow_null=True, default=None)
-    purchase = NestedPurchaseSerializer(required=False, allow_null=True, default=None)
-    tenant = NestedTenantSerializer(required=False, allow_null=True, default=None)
-    contact = NestedContactSerializer(required=False, allow_null=True, default=None)
-    owner = NestedTenantSerializer(required=False, allow_null=True, default=None)
+    device_type = DeviceTypeSerializer(nested=True, required=False, allow_null=True, default=None)
+    device = DeviceSerializer(nested=True, required=False, allow_null=True, default=None)
+    module_type = ModuleTypeSerializer(nested=True, required=False, allow_null=True, default=None)
+    module = ModuleSerializer(nested=True, required=False, allow_null=True, default=None)
+    inventoryitem_type = InventoryItemTypeSerializer(nested=True, required=False, allow_null=True, default=None) 
+    inventoryitem = InventoryItemSerializer(nested=True, required=False, allow_null=True, default=None)
+    storage_location = LocationSerializer(nested=True, required=False, allow_null=True, default=None)
+    delivery = DeliverySerializer(nested=True, required=False, allow_null=True, default=None)
+    purchase = PurchaseSerializer(nested=True, required=False, allow_null=True, default=None)
+    tenant = TenantSerializer(nested=True, required=False, allow_null=True, default=None)
+    contact = ContactSerializer(nested=True, required=False, allow_null=True, default=None)
+    owner = TenantSerializer(nested=True, required=False, allow_null=True, default=None)
 
     def to_internal_value(self, data):
         ret = super().to_internal_value(data)
@@ -49,6 +135,7 @@ class AssetSerializer(NetBoxModelSerializer):
             'warranty_start', 'warranty_end',
             'comments', 'tags', 'custom_fields', 'created', 'last_updated'
         )
+        brief_fields = ('id', 'url', 'display', 'serial')
         # DRF autiomatically creates validator from model's unique_together contraints
         # that doesn't work if we allow some filelds in a unique_together to be null
         # so we remove DRF's auto generated validators and rely on model's validation
@@ -56,84 +143,3 @@ class AssetSerializer(NetBoxModelSerializer):
         # see  https://www.django-rest-framework.org/api-guide/validators/#optional-fields
         validators = []
 
-
-class SupplierSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:supplier-detail'
-    )
-    asset_count = serializers.IntegerField(read_only=True)
-    purchase_count = serializers.IntegerField(read_only=True)
-    delivery_count = serializers.IntegerField(read_only=True)
-    
-    class Meta:
-        model = Supplier
-        fields = (
-            'id', 'url', 'display', 'name', 'slug', 'description', 'comments',
-            'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
-            'purchase_count', 'delivery_count',
-        )
-
-
-class PurchaseSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:purchase-detail'
-    )
-    supplier = NestedSupplierSerializer()
-    asset_count = serializers.IntegerField(read_only=True)
-    delivery_count = serializers.IntegerField(read_only=True)
-    
-    class Meta:
-        model = Purchase
-        fields = (
-            'id', 'url', 'display', 'supplier', 'name', 'status', 'date', 'description',
-            'comments', 'tags', 'custom_fields', 'created', 'last_updated',
-            'asset_count', 'delivery_count',
-        )
-
-
-class DeliverySerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:delivery-detail'
-    )
-    purchase = NestedPurchaseSerializer()
-    receiving_contact = NestedContactSerializer(required=False, allow_null=True, default=None)
-    asset_count = serializers.IntegerField(read_only=True)
-    
-    class Meta:
-        model = Delivery
-        fields = (
-            'id', 'url', 'display', 'purchase', 'name', 'date', 'description', 'comments',
-            'receiving_contact', 'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
-        )
-
-
-class InventoryItemTypeSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:inventoryitemtype-detail'
-    )
-    manufacturer = NestedManufacturerSerializer()
-    inventoryitem_group = NestedInventoryItemGroupSerializer(required=False, allow_null=True, default=None)
-    asset_count = serializers.IntegerField(read_only=True)
-    
-    class Meta:
-        model = InventoryItemType
-        fields = (
-            'id', 'url', 'display', 'model', 'slug', 'manufacturer', 'part_number',
-            'inventoryitem_group', 'comments', 'tags', 'custom_fields', 'created',
-            'last_updated', 'asset_count',
-        )
-
-
-class InventoryItemGroupSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_inventory-api:inventoryitemgroup-detail'
-    )
-    parent = NestedInventoryItemGroupSerializer(required=False, allow_null=True, default=None)
-    asset_count = serializers.IntegerField(read_only=True)
-    
-    class Meta:
-        model = InventoryItemGroup
-        fields = (
-            'id', 'url', 'display', 'name', 'parent', 'comments', 'tags', 'custom_fields',
-            'created', 'last_updated', 'asset_count',
-        )

--- a/netbox_inventory/api/serializers.py
+++ b/netbox_inventory/api/serializers.py
@@ -26,7 +26,7 @@ class SupplierSerializer(NetBoxModelSerializer):
             'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
             'purchase_count', 'delivery_count',
         )
-        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description')
 
 
 class PurchaseSerializer(NetBoxModelSerializer):
@@ -44,7 +44,7 @@ class PurchaseSerializer(NetBoxModelSerializer):
             'comments', 'tags', 'custom_fields', 'created', 'last_updated',
             'asset_count', 'delivery_count',
         )
-        brief_fields = ('id', 'url', 'display', 'supplier', 'name', 'status', 'date')
+        brief_fields = ('id', 'url', 'display', 'supplier', 'name', 'status', 'date', 'description')
 
 
 class DeliverySerializer(NetBoxModelSerializer):
@@ -61,7 +61,7 @@ class DeliverySerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'purchase', 'name', 'date', 'description', 'comments',
             'receiving_contact', 'tags', 'custom_fields', 'created', 'last_updated', 'asset_count',
         )
-        brief_fields = ('id', 'url', 'display', 'name', 'date')
+        brief_fields = ('id', 'url', 'display', 'name', 'date', 'description')
 
 
 class InventoryItemGroupSerializer(NestedGroupModelSerializer):
@@ -135,7 +135,7 @@ class AssetSerializer(NetBoxModelSerializer):
             'warranty_start', 'warranty_end',
             'comments', 'tags', 'custom_fields', 'created', 'last_updated'
         )
-        brief_fields = ('id', 'url', 'display', 'serial')
+        brief_fields = ('id', 'url', 'display', 'serial', 'name')
         # DRF autiomatically creates validator from model's unique_together contraints
         # that doesn't work if we allow some filelds in a unique_together to be null
         # so we remove DRF's auto generated validators and rely on model's validation

--- a/netbox_inventory/api/views.py
+++ b/netbox_inventory/api/views.py
@@ -1,6 +1,6 @@
 from dcim.api.views import DeviceViewSet, InventoryItemViewSet, ModuleViewSet
 from netbox.api.viewsets import NetBoxModelViewSet
-from utilities.utils import count_related
+from utilities.query import count_related
 from .. import filtersets, models
 from .serializers import (
     AssetSerializer, InventoryItemTypeSerializer, InventoryItemGroupSerializer,

--- a/netbox_inventory/forms/assign.py
+++ b/netbox_inventory/forms/assign.py
@@ -4,6 +4,7 @@ from dcim.models import Device, InventoryItem, Module, Site
 from netbox.forms import NetBoxModelForm
 from tenancy.models import Contact, Tenant
 from utilities.forms.fields import DynamicModelChoiceField
+from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import APISelect
 from ..models import Asset
 
@@ -93,9 +94,9 @@ class AssetDeviceAssignForm(AssetAssignMixin, NetBoxModelForm):
     )
 
     fieldsets = (
-        ('Asset', ('device_type', 'name')),
-        ('Device', ('site', 'device')),
-        ('Assigned to', ('tenant', 'contact')),
+        FieldSet('device_type', 'name', name='Asset'),
+        FieldSet('site', 'device', name='Device'),
+        FieldSet('tenant', 'contact', name='Assigned to'),
     )
 
     class Meta:
@@ -131,9 +132,9 @@ class AssetModuleAssignForm(AssetAssignMixin, NetBoxModelForm):
     )
 
     fieldsets = (
-        ('Asset', ('module_type', 'name')),
-        ('Module', ('device', 'module',)),
-        ('Tenancy', ('tenant', 'contact')),
+        FieldSet('module_type', 'name', name='Asset'),
+        FieldSet('device', 'module', name='Module'),
+        FieldSet('tenant', 'contact', name='Tenancy'),
     )
 
     class Meta:
@@ -175,9 +176,9 @@ class AssetInventoryItemAssignForm(AssetAssignMixin, NetBoxModelForm):
     )
 
     fieldsets = (
-        ('Asset', ('inventoryitem_type', 'name')),
-        ('Inventory Item', ('device', 'inventoryitem')),
-        ('Tenancy', ('tenant', 'contact')),
+        FieldSet('inventoryitem_type', 'name', name='Asset'),
+        FieldSet('device', 'inventoryitem', name='Inventory Item'),
+        FieldSet('tenant', 'contact', name='Tenancy'),
     )
 
     class Meta:

--- a/netbox_inventory/forms/bulk.py
+++ b/netbox_inventory/forms/bulk.py
@@ -9,6 +9,7 @@ from utilities.forms.fields import (
     CommentField, CSVChoiceField, CSVModelChoiceField,
     DynamicModelChoiceField
 )
+from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import DatePicker
 from tenancy.models import Contact, Tenant
 from ..choices import AssetStatusChoices, HardwareKindChoices, PurchaseStatusChoices
@@ -106,11 +107,11 @@ class AssetBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Asset
     fieldsets = (
-        ('General', ('name', 'status')),
-        ('Hardware', ('device_type', 'device', 'module_type', 'module')),
-        ('Purchase', ('owner', 'purchase', 'delivery', 'warranty_start', 'warranty_end')), 
-        ('Assigned to', ('tenant', 'contact')), 
-        ('Location', ('storage_location',)),
+        FieldSet('name', 'status', name='General'),
+        FieldSet('device_type', 'device', 'module_type', 'module', name='Hardware'),
+        FieldSet('owner', 'purchase', 'delivery', 'warranty_start', 'warranty_end', name='Purchase'), 
+        FieldSet('tenant', 'contact', name='Assigned to'), 
+        FieldSet('storage_location', name='Location'),
     )
     nullable_fields = (
         'name', 'device', 'module', 'owner', 'purchase', 'delivery', 'tenant', 'contact',
@@ -427,7 +428,7 @@ class SupplierBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Supplier
     fieldsets = (
-        ('General', ('description',)),
+        FieldSet('description', name='General'),
     )
     nullable_fields = ('description',)
 
@@ -476,7 +477,7 @@ class PurchaseBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Purchase
     fieldsets = (
-        ('General', ('date', 'status', 'supplier', 'description',)),
+        FieldSet('date', 'status', 'supplier', 'description', name='General'),
     )
     nullable_fields = ('date', 'description',)
 
@@ -527,7 +528,7 @@ class DeliveryBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Delivery
     fieldsets = (
-        ('General', ('date', 'purchase', 'receiving_contact', 'description',)),
+        FieldSet('date', 'purchase', 'receiving_contact', 'description', name='General'),
     )
     nullable_fields = ('date', 'description', 'receiving_contact',)
 
@@ -570,7 +571,7 @@ class InventoryItemTypeBulkEditForm(NetBoxModelBulkEditForm):
 
     model = InventoryItemType
     fieldsets = (
-        ('Inventory Item Type', ('manufacturer', 'inventoryitem_group')),
+        FieldSet('manufacturer', 'inventoryitem_group', name='Inventory Item Type'),
     )
     nullable_fields = (
         'inventoryitem_group',
@@ -602,6 +603,6 @@ class InventoryItemGroupBulkEditForm(NetBoxModelBulkEditForm):
 
     model = InventoryItemGroup
     fieldsets = (
-        (None, ('parent',)),
+        FieldSet('parent'),
     )
     nullable_fields = ('parent',)

--- a/netbox_inventory/forms/bulk_add.py
+++ b/netbox_inventory/forms/bulk_add.py
@@ -1,6 +1,5 @@
 from django import forms
 
-from utilities.forms import BootstrapMixin
 from .models import AssetForm
 
 
@@ -10,7 +9,7 @@ __all__ = (
 )
 
 
-class AssetBulkAddForm(BootstrapMixin, forms.Form):
+class AssetBulkAddForm(forms.Form):
     """ Form for creating multiple Assets by count """
     count = forms.IntegerField(
         min_value=1,

--- a/netbox_inventory/forms/create.py
+++ b/netbox_inventory/forms/create.py
@@ -1,8 +1,8 @@
 import logging
 
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
+from core.models import ObjectType
 from dcim.forms import DeviceForm, InventoryItemForm, ModuleForm
 from dcim.models import Device
 from utilities.forms.fields import DynamicModelChoiceField
@@ -124,7 +124,7 @@ class AssetInventoryItemCreateForm(AssetCreateMixin, InventoryItemForm):
                 raise ValidationError('Only a single component can be selected')
             if field_value:
                 component_set = field_name
-                self.cleaned_data['component_type'] = ContentType.objects.get(app_label='dcim', model=field_name)
+                self.cleaned_data['component_type'] = ObjectType.objects.get(app_label='dcim', model=field_name)
                 self.cleaned_data['component_id'] = field_value.pk
                 self.cleaned_data.pop(field_name)
 

--- a/netbox_inventory/forms/filters.py
+++ b/netbox_inventory/forms/filters.py
@@ -4,6 +4,7 @@ from dcim.models import Device, DeviceType, Manufacturer, ModuleType, Site, Loca
 from netbox.forms import NetBoxModelFilterSetForm
 from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES
 from utilities.forms.fields import DynamicModelMultipleChoiceField, TagFilterField
+from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import DatePicker
 from tenancy.forms import ContactModelFilterForm
 from tenancy.models import Contact, Tenant
@@ -24,23 +25,26 @@ __all__ = (
 class AssetFilterForm(NetBoxModelFilterSetForm):
     model = Asset
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag', 'status')),
-        ('Hardware', (
+        FieldSet('q', 'filter_id', 'tag', 'status'),
+        FieldSet(
             'kind', 'manufacturer_id', 'device_type_id', 'module_type_id',
-            'inventoryitem_type_id', 'inventoryitem_group_id', 'is_assigned'
-        )),
-        ('Usage', ('tenant_id', 'contact_id')),
-        ('Purchase', (
+            'inventoryitem_type_id', 'inventoryitem_group_id', 'is_assigned',
+            name='Hardware'
+        ),
+        FieldSet('tenant_id', 'contact_id', name='Usage'),
+        FieldSet(
             'owner_id', 'delivery_id', 'purchase_id', 'supplier_id',
             'delivery_date_after', 'delivery_date_before', 'purchase_date_after',
             'purchase_date_before', 'warranty_start_after', 'warranty_start_before',
-            'warranty_end_after', 'warranty_end_before'
-        )),
-        ('Location', (
+            'warranty_end_after', 'warranty_end_before',
+            name='Purchase'
+        ),
+        FieldSet(
             'storage_site_id', 'storage_location_id', 'installed_site_id', 
             'installed_location_id', 'installed_rack_id', 'installed_device_id',
             'located_site_id', 'located_location_id',
-        )),
+            name='Location',
+        ),
     )
 
     status = forms.MultipleChoiceField(
@@ -244,8 +248,8 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
 class SupplierFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):
     model = Supplier
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag')),
-        ('Contacts', ('contact', 'contact_role', 'contact_group')),
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('contact', 'contact_role', 'contact_group', name='Contacts'),
     )
 
     tag = TagFilterField(model)
@@ -254,8 +258,8 @@ class SupplierFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):
 class PurchaseFilterForm(NetBoxModelFilterSetForm):
     model = Purchase
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag')),
-        ('Purchase', ('supplier_id', 'status', 'date_after', 'date_before')),
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('supplier_id', 'status', 'date_after', 'date_before', name='Purchase'),
     )
 
     supplier_id = DynamicModelMultipleChoiceField(
@@ -283,14 +287,14 @@ class PurchaseFilterForm(NetBoxModelFilterSetForm):
 class DeliveryFilterForm(NetBoxModelFilterSetForm):
     model = Delivery
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag')),
-        ('Delivery', (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet(
             'purchase_id',
             'supplier_id',
             'receiving_contact_id',
             'date_after',
-            'date_before'
-        )),
+            'date_before',
+            name='Delivery'),
     )
 
     purchase_id = DynamicModelMultipleChoiceField(
@@ -324,8 +328,8 @@ class DeliveryFilterForm(NetBoxModelFilterSetForm):
 class InventoryItemTypeFilterForm(NetBoxModelFilterSetForm):
     model = InventoryItemType
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag')),
-        ('Inventory Item Type', ('manufacturer_id', 'inventoryitem_group_id')),
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('manufacturer_id', 'inventoryitem_group_id', name='Inventory Item Type'),
     )
     manufacturer_id = DynamicModelMultipleChoiceField(
         queryset=Manufacturer.objects.all(),
@@ -343,7 +347,7 @@ class InventoryItemTypeFilterForm(NetBoxModelFilterSetForm):
 class InventoryItemGroupFilterForm(NetBoxModelFilterSetForm):
     model = InventoryItemGroup
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag', 'parent_id')),
+        FieldSet('q', 'filter_id', 'tag', 'parent_id'),
     )
     parent_id = DynamicModelMultipleChoiceField(
         queryset=InventoryItemGroup.objects.all(),

--- a/netbox_inventory/forms/models.py
+++ b/netbox_inventory/forms/models.py
@@ -2,6 +2,7 @@ from dcim.models import DeviceType, Manufacturer, ModuleType, Location, Site
 from netbox.forms import NetBoxModelForm
 from netbox_inventory.choices import HardwareKindChoices
 from utilities.forms.fields import CommentField, DynamicModelChoiceField, SlugField
+from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import DatePicker
 from tenancy.models import Contact, Tenant
 from ..models import Asset, Delivery, InventoryItemType, InventoryItemGroup, Purchase, Supplier
@@ -94,41 +95,11 @@ class AssetForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        ('General', ('name', 'asset_tag', 'tags', 'status')),
-        (
-            'Hardware',
-            (
-                'serial',
-                'manufacturer',
-                'device_type',
-                'module_type',
-                'inventoryitem_type',
-            ),
-        ),
-        (
-            'Purchase',
-            (
-                'owner',
-                'purchase',
-                'delivery',
-                'warranty_start',
-                'warranty_end',
-            ),
-        ),
-        (
-            'Assigned to',
-            (
-                'tenant',
-                'contact',
-            ),
-        ),
-        (
-            'Location',
-            (
-                'storage_site',
-                'storage_location',
-            ),
-        ),
+        FieldSet('name', 'asset_tag', 'tags', 'status', name='General'),
+        FieldSet('serial', 'manufacturer', 'device_type', 'module_type', 'inventoryitem_type', name='Hardware'),
+        FieldSet('owner', 'purchase', 'delivery', 'warranty_start', 'warranty_end', name='Purchase'),
+        FieldSet('tenant', 'contact', name='Assigned to'),
+        FieldSet('storage_site', 'storage_location', name='Location'),
     )
 
     class Meta:
@@ -213,7 +184,9 @@ class SupplierForm(NetBoxModelForm):
     slug = SlugField(slug_source='name')
     comments = CommentField()
 
-    fieldsets = (('Supplier', ('name', 'slug', 'description', 'tags')),)
+    fieldsets = (
+        FieldSet('name', 'slug', 'description', 'tags', name='Supplier'),
+    )
 
     class Meta:
         model = Supplier
@@ -229,7 +202,9 @@ class SupplierForm(NetBoxModelForm):
 class PurchaseForm(NetBoxModelForm):
     comments = CommentField()
 
-    fieldsets = (('Purchase', ('supplier', 'name', 'status', 'date', 'description', 'tags')),)
+    fieldsets = (
+        FieldSet('supplier', 'name', 'status', 'date', 'description', 'tags', name='Purchase'),
+    )
 
     class Meta:
         model = Purchase
@@ -250,14 +225,9 @@ class PurchaseForm(NetBoxModelForm):
 class DeliveryForm(NetBoxModelForm):
     comments = CommentField()
 
-    fieldsets = (('Delivery', (
-        'purchase',
-        'name',
-        'date',
-        'receiving_contact',
-        'description',
-        'tags'
-    )),)
+    fieldsets = (
+        FieldSet('purchase', 'name', 'date', 'receiving_contact', 'description', 'tags', name='Delivery'),
+    )
 
     class Meta:
         model = Delivery
@@ -280,10 +250,7 @@ class InventoryItemTypeForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        (
-            'Inventory Item Type',
-            ('manufacturer', 'model', 'slug', 'part_number', 'inventoryitem_group', 'tags'),
-        ),
+        FieldSet('manufacturer', 'model', 'slug', 'part_number', 'inventoryitem_group', 'tags', name='Inventory Item Type'),
     )
 
     class Meta:
@@ -303,10 +270,7 @@ class InventoryItemGroupForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        (
-            'Inventory Item Group',
-            ('name', 'parent', 'tags'),
-        ),
+        FieldSet('name', 'parent', 'tags', name='Inventory Item Group'),
     )
 
     class Meta:

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from extras.plugins import PluginMenuItem, PluginMenuButton
+from netbox.plugins import PluginMenuItem, PluginMenuButton
 from utilities.choices import ButtonColorChoices
 
 # compatibility with netbox v3.3 that does not have PluginMenu
 try:
-    from extras.plugins import PluginMenu
+    from netbox.plugins import PluginMenu
     HAVE_MENU = True
 except ImportError:
     HAVE_MENU = False

--- a/netbox_inventory/navigation.py
+++ b/netbox_inventory/navigation.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from netbox.plugins import PluginMenuItem, PluginMenuButton
-from utilities.choices import ButtonColorChoices
 
 # compatibility with netbox v3.3 that does not have PluginMenu
 try:
@@ -16,14 +15,12 @@ asset_buttons = [
         link='plugins:netbox_inventory:asset_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_asset"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:asset_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_asset"],
     )
 ]
@@ -33,14 +30,12 @@ supplier_buttons = [
         link='plugins:netbox_inventory:supplier_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_supplier"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:supplier_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_supplier"],
     )
 ]
@@ -50,14 +45,12 @@ purchase_buttons = [
         link='plugins:netbox_inventory:purchase_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_purchase"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:purchase_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_purchase"],
     )
 ]
@@ -67,14 +60,12 @@ delivery_buttons = [
         link='plugins:netbox_inventory:delivery_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_delivery"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:delivery_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_delivery"],
     )
 ]
@@ -84,14 +75,12 @@ inventoryitemtype_buttons = [
         link='plugins:netbox_inventory:inventoryitemtype_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_inventoryitemtype"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:inventoryitemtype_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_inventoryitemtype"],
     )
 ]
@@ -101,14 +90,12 @@ inventoryitemgroup_buttons = [
         link='plugins:netbox_inventory:inventoryitemgroup_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN,
         permissions=["netbox_inventory.add_inventoryitemgroup"],
     ),
     PluginMenuButton(
         link='plugins:netbox_inventory:inventoryitemgroup_import',
         title='Import',
         icon_class='mdi mdi-upload',
-        color=ButtonColorChoices.CYAN,
         permissions=["netbox_inventory.add_inventoryitemgroup"],
     )
 ]

--- a/netbox_inventory/template_content.py
+++ b/netbox_inventory/template_content.py
@@ -1,5 +1,5 @@
 from django.template import Template
-from extras.plugins import PluginTemplateExtension
+from netbox.plugins import PluginTemplateExtension
 
 from .models import Asset
 

--- a/netbox_inventory/template_content.py
+++ b/netbox_inventory/template_content.py
@@ -10,34 +10,40 @@ WARRANTY_PROGRESSBAR = '''
 {% with settings.PLUGINS_CONFIG.netbox_inventory.asset_warranty_expire_warning_days as wthresh %}
 
 {% if wp is None and wr.days <= 0 %}
-    <div class="progress"><div role="progressbar" class="progress-bar progress-bar-striped bg-danger" style="width:100%;">Expired {{ record.warranty_end|timesince|split:','|first }} ago</div></div>
+  <div class="progress" role="progressbar">
+    <div class="progress-bar progress-bar-striped text-bg-danger" style="width:100%;">
+      Expired {{ record.warranty_end|timesince|split:','|first }} ago
+    </div>
+  </div>
 {% elif wp is None and wr.days > 0 %}
-    <div class="progress"><div role="progressbar" class="progress-bar progress-bar-striped {% if wthresh and wr.days < wthresh %}bg-warning{% else %}bg-success{% endif %}" style="width:100%;">{{ record.warranty_end|timeuntil|split:','|first }}</div></div>
+  <div class="progress" role="progressbar">
+    <div class="progress-bar progress-bar-striped text-bg-{% if wthresh and wr.days < wthresh %}warning{% else %}success{% endif %}" style="width:100%;">
+      {{ record.warranty_end|timeuntil|split:','|first }}
+    </div>
+  </div>
 {% elif wp is None %}
-    <span class="text-muted">No data</span>
+    {{ ""|placeholder }}
 {% else %}
 
-<div class="progress">
+<div
+  class="progress"
+  role="progressbar"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-valuenow="{% if wp < 0 %}0{% else %}{{ wp }}{% endif %}"
+>
   <div
-    role="progressbar"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="{% if wp < 0 %}0{% else %}{{ wp }}{% endif %}"
-    class="progress-bar {% if wp >= 100 %}bg-danger{% elif wthresh and wr.days < wthresh %}bg-warning{% else %}bg-success{% endif %}"
+    class="progress-bar text-bg-{% if wp >= 100 %}danger{% elif wthresh and wr.days < wthresh %}warning{% else %}success{% endif %}"
     style="width: {% if wp < 0 %}0%{% else %}{{ wp }}%{% endif %};"
-  >
+  ></div>
   {% if record.warranty_progress >= 100 %}
-    Expired {{ record.warranty_end|timesince|split:','|first }} ago
-  </div>
+    <span class="justify-content-center d-flex align-items-center position-absolute text-light w-100 h-100">Expired {{ record.warranty_end|timesince|split:','|first }} ago</span>
   {% elif record.warranty_progress >= 35 %}
-    {{ record.warranty_end|timeuntil|split:','|first }}
-  </div>
+    <span class="justify-content-center d-flex align-items-center position-absolute text-body-emphasis w-100 h-100">{{ record.warranty_end|timeuntil|split:','|first }}</span>
   {% elif record.warranty_progress >= 0 %}
-  </div>
-    <span class="ps-1">{{ record.warranty_end|timeuntil|split:','|first }}</span>
+    <span class="justify-content-center d-flex align-items-center position-absolute text-body-emphasis w-100 h-100">{{ record.warranty_end|timeuntil|split:','|first }}</span>
   {% else %}
-  </div>
-    <span class="text-center" style="width: 100%">Starts in {{ record.warranty_start|timeuntil|split:','|first }}</span>
+    <span class="justify-content-center d-flex align-items-center position-absolute text-body-emphasis w-100 h-100">Starts in {{ record.warranty_start|timeuntil|split:','|first }}</span>
   {% endif %}
 </div>
 

--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -155,19 +155,19 @@
             </tr>
             <tr>
               <th scope="row">Purchase</th>
-              <td>{{ object.purchase|linkify|placeholder }}{% if object.purchase.date %} on {{ object.purchase.date|annotated_date }}{% endif %}</td>
+              <td>{{ object.purchase|linkify|placeholder }}{% if object.purchase.date %} on {{ object.purchase.date|isodate }}{% endif %}</td>
             </tr>
             <tr>
               <th scope="row">Delivery</th>
-              <td>{{ object.delivery|linkify:'name'|placeholder }}{% if object.delivery.date %} on {{ object.delivery.date|annotated_date }}{% endif %}</td>
+              <td>{{ object.delivery|linkify:'name'|placeholder }}{% if object.delivery.date %} on {{ object.delivery.date|isodate }}{% endif %}</td>
             </tr>
             <tr>
               <th scope="row">Warranty start</th>
-              <td>{{ object.warranty_start|annotated_date|placeholder }}</td>
+              <td>{{ object.warranty_start|isodate|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Warranty end</th>
-              <td>{{ object.warranty_end|annotated_date|placeholder }}</td>
+              <td>{{ object.warranty_end|isodate|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Warranty remaining</th>

--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -64,7 +64,29 @@
         </table>
       </div>
       <div class="card">
-        <h5 class="card-header">Assigned To</h5>
+        <h5 class="card-header">
+          Assigned To
+          <div class="card-actions">
+            {# only show create button if use has add permissions for the kind of hardware being created #}
+            {% if object.kind == 'device' and perms.dcim.add_device or object.kind == 'module' and perms.dcim.add_module or object.kind == 'inventoryitem' and perms.dcim.add_inventoryitem %}
+              {% if object.hardware %}
+                <a href="#" class="btn btn-sm btn-ghost-dark disabled">
+                  <i class="mdi mdi-vector-difference-ba" aria-hidden="true"></i> Create {{ object.get_kind_display }}
+                </a>
+              {% else %}
+                <a href="{% url 'plugins:netbox_inventory:asset_'|add:object.kind|add:'_create' %}?asset_id={{ object.pk }}" class="btn btn-sm btn-ghost-green" title="Create a new {{ object.get_kind_display }} from this asset">
+                  <i class="mdi mdi-vector-difference-ba" aria-hidden="true"></i> Create {{ object.get_kind_display }}
+                </a>
+              {% endif %}
+            {% endif %}
+            {# only show edit button if user has change permission on asset #}
+            {% if perms.netbox_inventory.change_asset %}
+              <a href="{% url 'plugins:netbox_inventory:asset_assign' object.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-orange">
+                <i class="mdi mdi-vector-link" aria-hidden="true"></i> Edit Assignment
+              </a>
+            {% endif %}
+          </div>
+        </h5>
         <table class="table table-hover attr-table">
           <tr>
             <th scope="row">Tenant</th>
@@ -84,26 +106,6 @@
             <td>{{ object.hardware|linkify|placeholder }}</td>
           </tr>
         </table>
-        <div class="card-footer text-end noprint">
-          {# only show create button if use has add permissions for the kind of hardware being created #}
-          {% if object.kind == 'device' and perms.dcim.add_device or object.kind == 'module' and perms.dcim.add_module or object.kind == 'inventoryitem' and perms.dcim.add_inventoryitem %}
-            {% if object.hardware %}
-            <a href="#" class="btn btn-sm btn-outline-dark disabled">
-              <span class="mdi mdi-vector-difference-ba" aria-hidden="true"></span> Create {{ object.get_kind_display }}
-            </a>
-            {% else %}
-            <a href="{% url 'plugins:netbox_inventory:asset_'|add:object.kind|add:'_create' %}?asset_id={{ object.pk }}" class="btn btn-sm btn-green" title="Create a new {{ object.get_kind_display }} from this asset">
-              <span class="mdi mdi-vector-difference-ba" aria-hidden="true"></span> Create {{ object.get_kind_display }}
-            </a>
-            {% endif %}
-          {% endif %}
-          {# only show edit button if user has change permission on asset #}
-          {% if perms.netbox_inventory.change_asset %}
-            <a href="{% url 'plugins:netbox_inventory:asset_assign' object.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-orange">
-              <span class="mdi mdi-vector-link" aria-hidden="true"></span> Edit Assignment
-            </a>
-          {% endif %}
-        </div>
       </div>
       <div class="card">
         <h5 class="card-header">Installed Location</h5>

--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -17,77 +17,73 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Asset</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ object.name|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Asset Tag</th>
-              <td class="font-monospace">{{ object.asset_tag|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Serial Number</th>
-              <td class="font-monospace">{{ object.serial|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Status</th>
-              <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ object.get_kind_display }} Type</th>
-              <td><a href="{{object.hardware_type.get_absolute_url}}">{{ object.hardware_type.manufacturer }} {{ object.hardware_type }}</a></td>
-            </tr>
-            {% if object.kind == 'inventoryitem' %}
-            <tr>
-              <th scope="row">Inventory Item Group</th>
-              <td>
-                {% if object.inventoryitem_type.inventoryitem_group %}
-                  {% for group in object.inventoryitem_type.inventoryitem_group.get_ancestors %}
-                    {{ group|linkify }} /
-                  {% endfor %}
-                  {{ object.inventoryitem_type.inventoryitem_group|linkify }}
-                {% else %}
-                  {{ ''|placeholder }}
-                {% endif %}
-              </td>
-            </tr>
-            {% endif %}
-            <tr>
-              <th scope="row" title="Where is this asset stored when not in use">Storage Location</th>
-              <td>
-                {% if object.storage_location %}
-                  {{ object.storage_location.site }} /
-                {% endif %}
-                {{ object.storage_location|linkify|placeholder }}</td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Asset Tag</th>
+            <td class="font-monospace">{{ object.asset_tag|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Serial Number</th>
+            <td class="font-monospace">{{ object.serial|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Status</th>
+            <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{{ object.get_kind_display }} Type</th>
+            <td><a href="{{object.hardware_type.get_absolute_url}}">{{ object.hardware_type.manufacturer }} {{ object.hardware_type }}</a></td>
+          </tr>
+          {% if object.kind == 'inventoryitem' %}
+          <tr>
+            <th scope="row">Inventory Item Group</th>
+            <td>
+              {% if object.inventoryitem_type.inventoryitem_group %}
+                {% for group in object.inventoryitem_type.inventoryitem_group.get_ancestors %}
+                  {{ group|linkify }} /
+                {% endfor %}
+                {{ object.inventoryitem_type.inventoryitem_group|linkify }}
+              {% else %}
+                {{ ''|placeholder }}
+              {% endif %}
+            </td>
+          </tr>
+          {% endif %}
+          <tr>
+            <th scope="row" title="Where is this asset stored when not in use">Storage Location</th>
+            <td>
+              {% if object.storage_location %}
+                {{ object.storage_location.site }} /
+              {% endif %}
+              {{ object.storage_location|linkify|placeholder }}</td>
+          </tr>
+        </table>
       </div>
       <div class="card">
         <h5 class="card-header">Assigned To</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Tenant</th>
-              <td>
-                {% if object.tenant.group %}
-                  {{ object.tenant.group|linkify }} /
-                {% endif %}
-                {{ object.tenant|linkify|placeholder }}
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Contact</th>
-              <td>{{ object.contact|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ object.get_kind_display }}</th>
-              <td>{{ object.hardware|linkify|placeholder }}</td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Tenant</th>
+            <td>
+              {% if object.tenant.group %}
+                {{ object.tenant.group|linkify }} /
+              {% endif %}
+              {{ object.tenant|linkify|placeholder }}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Contact</th>
+            <td>{{ object.contact|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{{ object.get_kind_display }}</th>
+            <td>{{ object.hardware|linkify|placeholder }}</td>
+          </tr>
+        </table>
         <div class="card-footer text-end noprint">
           {# only show create button if use has add permissions for the kind of hardware being created #}
           {% if object.kind == 'device' and perms.dcim.add_device or object.kind == 'module' and perms.dcim.add_module or object.kind == 'inventoryitem' and perms.dcim.add_inventoryitem %}
@@ -111,35 +107,33 @@
       </div>
       <div class="card">
         <h5 class="card-header">Installed Location</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Site</th>
-              <td>{{ object.installed_site|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Location</th>
-              <td>
-                {% if object.installed_location %}
-                  {% for location in object.installed_location.get_ancestors %}
-                    {{ location|linkify }} /
-                  {% endfor %}
-                  {{ object.installed_location|linkify }}
-                {% else %}
-                  {{ ''|placeholder }}
-                {% endif %}
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Rack</th>
-              <td>{{ object.installed_rack|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Device</th>
-              <td>{{ object.installed_device|linkify|placeholder }}</td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Site</th>
+            <td>{{ object.installed_site|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Location</th>
+            <td>
+              {% if object.installed_location %}
+                {% for location in object.installed_location.get_ancestors %}
+                  {{ location|linkify }} /
+                {% endfor %}
+                {{ object.installed_location|linkify }}
+              {% else %}
+                {{ ''|placeholder }}
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Rack</th>
+            <td>{{ object.installed_rack|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Device</th>
+            <td>{{ object.installed_device|linkify|placeholder }}</td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_left_page object %}
@@ -147,36 +141,34 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Purchase</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Owner</th>
-              <td>{{ object.owner|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Purchase</th>
-              <td>{{ object.purchase|linkify|placeholder }}{% if object.purchase.date %} on {{ object.purchase.date|isodate }}{% endif %}</td>
-            </tr>
-            <tr>
-              <th scope="row">Delivery</th>
-              <td>{{ object.delivery|linkify:'name'|placeholder }}{% if object.delivery.date %} on {{ object.delivery.date|isodate }}{% endif %}</td>
-            </tr>
-            <tr>
-              <th scope="row">Warranty start</th>
-              <td>{{ object.warranty_start|isodate|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Warranty end</th>
-              <td>{{ object.warranty_end|isodate|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Warranty remaining</th>
-              <td>
-                {% include warranty_progressbar with record=object %}
-              </td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Owner</th>
+            <td>{{ object.owner|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Purchase</th>
+            <td>{{ object.purchase|linkify|placeholder }}{% if object.purchase.date %} on {{ object.purchase.date|isodate }}{% endif %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Delivery</th>
+            <td>{{ object.delivery|linkify:'name'|placeholder }}{% if object.delivery.date %} on {{ object.delivery.date|isodate }}{% endif %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Warranty start</th>
+            <td>{{ object.warranty_start|isodate|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Warranty end</th>
+            <td>{{ object.warranty_end|isodate|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Warranty remaining</th>
+            <td>
+              {% include warranty_progressbar with record=object %}
+            </td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox_inventory/templates/netbox_inventory/asset_bulk_import.html
+++ b/netbox_inventory/templates/netbox_inventory/asset_bulk_import.html
@@ -22,39 +22,43 @@
                         <p>
                         Values bellow show your current config values.
                         </p>
-                        <table class="table">
-                            <tr>
-                                <th>Object name</th>
-                                <th>Created if missing?</th>
-                                <th>Plugin setting name</th>
-                            </tr>
-                            <tr>
-                                <td>Manufacturer & Device Type</td>
-                                <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_device_type %}</td>
-                                <td><code>asset_import_create_device_type</code></td>
-                            </tr>
-                            <tr>
-                                <td>Manufacturer & Module Type</td>
-                                <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_module_type %}</td>
-                                <td><code>asset_import_create_module_type</code></td>
-                            </tr>
-                            <tr>
-                                <td>Manufacturer & InventoryItem Type</td>
-                                <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_inventoryitem_type %}</td>
-                                <td><code>asset_import_create_inventoryitem_type</code></td>
-                            </tr>
-                            <tr>
-                                <td>Supplier & Purchase</td>
-                                <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_purchase %}</td>
-                                <td><code>asset_import_create_purchase</code></td>
-                            </tr>
-                            <tr>
-                                <td>Owner & Tenant</td>
-                                <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_tenant %}</td>
-                                <td><code>asset_import_create_tenant</code></td>
-                            </tr>
-                        </table>
                     </div>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Object name</th>
+                                    <th>Created if missing?</th>
+                                    <th>Plugin setting name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Manufacturer & Device Type</td>
+                                    <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_device_type %}</td>
+                                    <td class="font-monospace">asset_import_create_device_type</td>
+                                </tr>
+                                <tr>
+                                    <td>Manufacturer & Module Type</td>
+                                    <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_module_type %}</td>
+                                    <td class="font-monospace">asset_import_create_module_type</td>
+                                </tr>
+                                <tr>
+                                    <td>Manufacturer & InventoryItem Type</td>
+                                    <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_inventoryitem_type %}</td>
+                                    <td class="font-monospace">asset_import_create_inventoryitem_type</td>
+                                </tr>
+                                <tr>
+                                    <td>Supplier & Purchase</td>
+                                    <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_purchase %}</td>
+                                    <td class="font-monospace">asset_import_create_purchase</td>
+                                </tr>
+                                <tr>
+                                    <td>Owner & Tenant</td>
+                                    <td>{% checkmark settings.PLUGINS_CONFIG.netbox_inventory.asset_import_create_tenant %}</td>
+                                    <td class="font-monospace">asset_import_create_tenant</td>
+                                </tr>
+                            </tbody>
+                        </table>
                 </div>
             </div>
         </div>

--- a/netbox_inventory/templates/netbox_inventory/asset_bulk_import.html
+++ b/netbox_inventory/templates/netbox_inventory/asset_bulk_import.html
@@ -3,7 +3,7 @@
 {% load helpers %}
 {% load form_helpers %}
 
-{% block content-wrapper %}
+{% block content %}
 {{ block.super }}
 
     <div class="tab-content">
@@ -59,4 +59,4 @@
             </div>
         </div>
     </div>
-{% endblock content-wrapper %}
+{% endblock content %}

--- a/netbox_inventory/templates/netbox_inventory/delivery.html
+++ b/netbox_inventory/templates/netbox_inventory/delivery.html
@@ -18,7 +18,6 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Delivery</h5>
-        <div class="card-body">
           <table class="table table-hover attr-table">
             <tr>
               <th scope="row">Name</th>
@@ -48,7 +47,6 @@
             </tr>
           </table>
         </div>
-      </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/delivery.html
+++ b/netbox_inventory/templates/netbox_inventory/delivery.html
@@ -34,7 +34,7 @@
             </tr>
             <tr>
               <th scope="row">Date</th>
-              <td>{{ object.date|annotated_date|placeholder }}</td>
+              <td>{{ object.date|isodate|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Description</th>

--- a/netbox_inventory/templates/netbox_inventory/delivery.html
+++ b/netbox_inventory/templates/netbox_inventory/delivery.html
@@ -18,35 +18,35 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Delivery</h5>
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ object.name }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Purchase</th>
-              <td>{{ object.purchase|linkify }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Receiving Contact</th>
-              <td>{{ object.receiving_contact|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Date</th>
-              <td>{{ object.date|isodate|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Description</th>
-              <td>{{ object.description|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Assets</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:asset_list' %}?delivery_id={{ object.pk }}">{{ asset_count }}</a>
-              </td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Purchase</th>
+            <td>{{ object.purchase|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Receiving Contact</th>
+            <td>{{ object.receiving_contact|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Date</th>
+            <td>{{ object.date|isodate|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Assets</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:asset_list' %}?delivery_id={{ object.pk }}">{{ asset_count }}</a>
+            </td>
+          </tr>
+        </table>
+      </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
@@ -60,10 +60,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Delivered Assets</h5>
-        <div class="card-body htmx-container table-responsive"
-          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?delivery_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'plugins:netbox_inventory:asset_list' delivery_id=object.pk %}
         {% if perms.netbox_inventory.add_asset %}
           <div class="card-footer text-end noprint">
             <a href="{% url 'plugins:netbox_inventory:asset_add' %}?delivery={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">

--- a/netbox_inventory/templates/netbox_inventory/delivery.html
+++ b/netbox_inventory/templates/netbox_inventory/delivery.html
@@ -59,15 +59,17 @@
   <div class="row mb-3">
     <div class="col col-md-12">
       <div class="card">
-        <h5 class="card-header">Delivered Assets</h5>
+        <h5 class="card-header">
+          Delivered Assets
+          {% if perms.netbox_inventory.add_asset %}
+            <div class="card-actions">
+              <a href="{% url 'plugins:netbox_inventory:asset_add' %}?delivery={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+                <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
+              </a>
+            </div>
+          {% endif %}
+        </h5>
         {% htmx_table 'plugins:netbox_inventory:asset_list' delivery_id=object.pk %}
-        {% if perms.netbox_inventory.add_asset %}
-          <div class="card-footer text-end noprint">
-            <a href="{% url 'plugins:netbox_inventory:asset_add' %}?delivery={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-              <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
-            </a>
-          </div>
-        {% endif %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_info.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_info.html
@@ -1,7 +1,25 @@
 {% load helpers %}
 
 <div class="card">
-  <h5 class="card-header">Asset</h5>
+  <h5 class="card-header">
+    Asset
+    {# only show reassign button if user has change permissions on asset #}
+    {% if perms.netbox_inventory.change_asset %}
+      <div class="card-actions">
+        {% with object|meta:"model_name" as object_type %}
+        {% if object_type == "device" %}
+        <a href="{% url 'plugins:netbox_inventory:asset_device_reassign' object.pk %}" class="btn btn-sm btn-ghost-orange">
+        {% elif object_type == "module" %}
+        <a href="{% url 'plugins:netbox_inventory:asset_module_reassign' object.pk %}" class="btn btn-sm btn-ghost-orange">
+        {% elif object_type == "inventoryitem" %}
+        <a href="{% url 'plugins:netbox_inventory:asset_inventoryitem_reassign' object.pk %}" class="btn btn-sm btn-ghost-orange">
+        {% endif %}
+        {% endwith %}
+          <i class="mdi mdi-vector-link" aria-hidden="true"></i> Edit Assignment
+        </a>
+      </div>
+    {% endif %}
+  </h5>
   {% if asset %}
   <table class="table table-hover attr-table">
     <tr>
@@ -30,20 +48,4 @@
   {% else %}
   <div class="text-muted">None assigned</div>
   {% endif %}
-  <div class="card-footer text-end noprint">
-    {# only show reassign button if user has change permissions on asset #}
-    {% if perms.netbox_inventory.change_asset %}
-      {% with object|meta:"model_name" as object_type %}
-      {% if object_type == "device" %}
-      <a href="{% url 'plugins:netbox_inventory:asset_device_reassign' object.pk %}" class="btn btn-sm btn-orange">
-      {% elif object_type == "module" %}
-      <a href="{% url 'plugins:netbox_inventory:asset_module_reassign' object.pk %}" class="btn btn-sm btn-orange">
-      {% elif object_type == "inventoryitem" %}
-      <a href="{% url 'plugins:netbox_inventory:asset_inventoryitem_reassign' object.pk %}" class="btn btn-sm btn-orange">
-      {% endif %}
-      {% endwith %}
-        <span class="mdi mdi-vector-link" aria-hidden="true"></span> Edit Assignment
-      </a>
-    {% endif %}
-  </div>
 </div>

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_info.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_info.html
@@ -2,36 +2,34 @@
 
 <div class="card">
   <h5 class="card-header">Asset</h5>
-  <div class="card-body">
   {% if asset %}
-    <table class="table table-hover attr-table">
-      <tr>
-        <th scope="row"><span title="Asset name">Name</span></th>
-        <td><a href="{% url "plugins:netbox_inventory:asset" asset.pk %}">{{ asset.hardware_type.manufacturer }} {{ asset }}{% if asset.name %} ({{ asset.name }}){% endif %}</a></td>
-      </tr>
-      <tr>
-        <th scope="row"><span title="Asset status">Status</span></a></th>
-        <td>{% badge asset.get_status_display bg_color=asset.get_status_color %}</a></td>
-      </tr>
-      <tr>
-        <th scope="row">Owner</th>
-        <td>{{ asset.owner|linkify|placeholder }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Purchase</th>
-        <td>{{ asset.purchase|linkify|placeholder }}</td>
-      </tr>
-      <tr>
-        <th>Warranty remaining</th>
-        <td>
-          {% include warranty_progressbar with record=asset %}
-        </td>
-      </tr>
-    </table>
+  <table class="table table-hover attr-table">
+    <tr>
+      <th scope="row"><span title="Asset name">Name</span></th>
+      <td><a href="{% url "plugins:netbox_inventory:asset" asset.pk %}">{{ asset.hardware_type.manufacturer }} {{ asset }}{% if asset.name %} ({{ asset.name }}){% endif %}</a></td>
+    </tr>
+    <tr>
+      <th scope="row"><span title="Asset status">Status</span></a></th>
+      <td>{% badge asset.get_status_display bg_color=asset.get_status_color %}</a></td>
+    </tr>
+    <tr>
+      <th scope="row">Owner</th>
+      <td>{{ asset.owner|linkify|placeholder }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Purchase</th>
+      <td>{{ asset.purchase|linkify|placeholder }}</td>
+    </tr>
+    <tr>
+      <th>Warranty remaining</th>
+      <td>
+        {% include warranty_progressbar with record=asset %}
+      </td>
+    </tr>
+  </table>
   {% else %}
-    <div class="text-muted">None assigned</div>
+  <div class="text-muted">None assigned</div>
   {% endif %}
-  </div>
   <div class="card-footer text-end noprint">
     {# only show reassign button if user has change permissions on asset #}
     {% if perms.netbox_inventory.change_asset %}

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_stats_counts.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_stats_counts.html
@@ -7,9 +7,9 @@
       <a href="{% url 'plugins:netbox_inventory:asset_list' %}?{{ asset_stat.filter_field }}={{ object.pk }}{{ asset_stat.extra_filter }}" class="list-group-item list-group-item-action d-flex justify-content-between">
         {{ asset_stat.label|bettertitle }}
         {% if asset_stat.count %}
-          <span class="badge bg-primary rounded-pill">{{ asset_stat.count }}</span>
+          <span class="badge text-bg-primary rounded-pill">{{ asset_stat.count }}</span>
         {% else %}
-          <span class="badge bg-light rounded-pill">&mdash;</span>
+          <span class="badge text-bg-light rounded-pill">&mdash;</span>
         {% endif %}
       </tr>
       </a>

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
@@ -23,90 +23,84 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Inventory Item Group</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ object.name }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Parent</th>
-              <td>{{ object.parent|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Assets</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_group_id={{ object.pk }}">{{ asset_table.rows|length }}</a>
-              </td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Parent</th>
+            <td>{{ object.parent|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Assets</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_group_id={{ object.pk }}">{{ asset_table.rows|length }}</a>
+            </td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
 
 
         <div class="card">
         <h5 class="card-header">Asset count by status</h5>
-        <div class="card-body">
-          <table class="table table-hover object-list">
-          <thead>
-            <tr>
-              <th>Status</th>
-              <th>Count</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for sc in status_counts.values %}
-            <tr>
-              <td>{% badge value=sc.label bg_color=sc.color %}</td>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_group_id={{ object.pk }}&status={{ sc.value }}">
-                  {{ sc.count }}
-                </a>
-              </td>
-            </tr>
-            {% empty %}
-            <tr><td class="text-center text-muted" colspan="2">— No assets found —</td></tr>
-            {% endfor %}
-          </tbody>
-          </table>
-        </div>
+        <table class="table table-hover object-list">
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for sc in status_counts.values %}
+          <tr>
+            <td>{% badge value=sc.label bg_color=sc.color %}</td>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_group_id={{ object.pk }}&status={{ sc.value }}">
+                {{ sc.count }}
+              </a>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td class="text-center text-muted" colspan="2">— No assets found —</td></tr>
+          {% endfor %}
+        </tbody>
+        </table>
       </div>
 
       <div class="card">
         <h5 class="card-header">Asset count by type & status</h5>
-        <div class="card-body">
-          <table class="table table-hover object-list table-striped">
-          <thead>
-            <tr>
-              <th>Inventory Item Type</th>
-              <th>Status - Count</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for tsc in type_status_objects %}
-            <tr>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:inventoryitemtype' tsc.inventoryitem_type %}">
-                  {{ tsc.inventoryitem_type__manufacturer__name }} {{ tsc.inventoryitem_type__model }}
-                </a>
-              </td>
-              <td style="max-width:400px;">
-                <div class="d-flex" style="overflow:auto;">
-                  {% for status in tsc.status_list %}
-                    <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_type_id={{ tsc.inventoryitem_type }}&status={{ status.status }}" class="w-100 me-2">
-                      {% badge value=status.label|add:' - '|add:status.count bg_color=status.color|add:' w-100' %}
-                    </a>
-                  {% endfor %}
-                </div>
-              </td>
-            </tr>
-            {% empty %}
-            <tr><td class="text-center text-muted" colspan="2">— No assets found —</td></tr>
-            {% endfor %}
-          </tbody>
-          </table>
-        </div>
+        <table class="table table-hover object-list table-striped">
+        <thead>
+          <tr>
+            <th>Inventory Item Type</th>
+            <th>Status - Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for tsc in type_status_objects %}
+          <tr>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:inventoryitemtype' tsc.inventoryitem_type %}">
+                {{ tsc.inventoryitem_type__manufacturer__name }} {{ tsc.inventoryitem_type__model }}
+              </a>
+            </td>
+            <td style="max-width:400px;">
+              <div class="d-flex" style="overflow:auto;">
+                {% for status in tsc.status_list %}
+                  <a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_type_id={{ tsc.inventoryitem_type }}&status={{ status.status }}" class="w-100 me-2">
+                    {% badge value=status.label|add:' - '|add:status.count bg_color=status.color|add:' w-100' %}
+                  </a>
+                {% endfor %}
+              </div>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td class="text-center text-muted" colspan="2">— No assets found —</td></tr>
+          {% endfor %}
+        </tbody>
+        </table>
       </div>
       {% plugin_left_page object %}
     </div>
@@ -115,9 +109,7 @@
         <h5 class="card-header">
           Child Groups
         </h5>
-        <div class="card-body table-responsive">
-          {% render_table child_groups_table 'inc/table.html' %}
-        </div>
+        {% render_table child_groups_table 'inc/table.html' %}
         {% if perms.netbox_inventory.add_inventoryitemgroup %}
           <div class="card-footer text-end noprint">
             <a href="{% url 'plugins:netbox_inventory:inventoryitemgroup_add' %}?parent={{ object.pk }}" class="btn btn-sm btn-primary">
@@ -135,10 +127,8 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Assets</h5>
-        <div class="card-body table-responsive">
-          {% render_table asset_table 'inc/table.html' %}
-          {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
-        </div>
+        {% render_table asset_table 'inc/table.html' %}
+        {% include 'inc/paginator.html' with paginator=asset_table.paginator page=asset_table.page %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
@@ -108,15 +108,15 @@
       <div class="card">
         <h5 class="card-header">
           Child Groups
+          {% if perms.netbox_inventory.add_inventoryitemgroup %}
+            <div class="card-actions">
+              <a href="{% url 'plugins:netbox_inventory:inventoryitemgroup_add' %}?parent={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+                <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add Group
+              </a>
+            </div>
+          {% endif %}
         </h5>
         {% render_table child_groups_table 'inc/table.html' %}
-        {% if perms.netbox_inventory.add_inventoryitemgroup %}
-          <div class="card-footer text-end noprint">
-            <a href="{% url 'plugins:netbox_inventory:inventoryitemgroup_add' %}?parent={{ object.pk }}" class="btn btn-sm btn-primary">
-              <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Group
-            </a>
-          </div>
-        {% endif %}
       </div>
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemgroup.html
@@ -12,7 +12,7 @@
 
 {% block extra_controls %}
   {% if perms.netbox_inventory.add_inventoryitemtype %}
-    <a href="{% url 'plugins:netbox_inventory:inventoryitemtype_add' %}?inventoryitem_group={{ object.pk }}" class="btn btn-sm btn-primary">
+    <a href="{% url 'plugins:netbox_inventory:inventoryitemtype_add' %}?inventoryitem_group={{ object.pk }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add inventory item type
     </a>
   {% endif %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
@@ -10,7 +10,7 @@
 
 {% block extra_controls %}
   {% if perms.netbox_inventory.add_asset %}
-    <a href="{% url 'plugins:netbox_inventory:asset_add' %}?inventoryitem_type={{ object.pk }}&manufacturer={{ object.manufacturer.pk }}" class="btn btn-sm btn-primary">
+    <a href="{% url 'plugins:netbox_inventory:asset_add' %}?inventoryitem_type={{ object.pk }}&manufacturer={{ object.manufacturer.pk }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add asset
     </a>
   {% endif %}

--- a/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
+++ b/netbox_inventory/templates/netbox_inventory/inventoryitemtype.html
@@ -21,30 +21,28 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Inventory Item Type</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Manufacturer</th>
-              <td>{{ object.manufacturer|linkify }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Model</th>
-              <td>{{ object.model }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Part number</th>
-              <td>{{ object.part_number }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Group</th>
-              <td>{{ object.inventoryitem_group|linkify|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Assets</th>
-              <td><a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_type_id={{ object.pk }}">{{ asset_count }}</a></td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Manufacturer</th>
+            <td>{{ object.manufacturer|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Model</th>
+            <td>{{ object.model }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Part number</th>
+            <td>{{ object.part_number }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Group</th>
+            <td>{{ object.inventoryitem_group|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Assets</th>
+            <td><a href="{% url 'plugins:netbox_inventory:asset_list' %}?inventoryitem_type_id={{ object.pk }}">{{ asset_count }}</a></td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_left_page object %}

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -31,7 +31,7 @@
             </tr>
             <tr>
               <th scope="row">Date</th>
-              <td>{{ object.date|annotated_date|placeholder }}</td>
+              <td>{{ object.date|isodate|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Description</th>

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -63,10 +63,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Deliveries</h5>
-        <div class="card-body htmx-container table-responsive"
-          hx-get="{% url 'plugins:netbox_inventory:delivery_list' %}?purchase_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'plugins:netbox_inventory:delivery_list' purchase_id=object.pk %}
         {% if perms.netbox_inventory.add_delivery %}
           <div class="card-footer text-end noprint">
             <a href="{% url 'plugins:netbox_inventory:delivery_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
@@ -77,10 +74,7 @@
       </div>
       <div class="card">
         <h5 class="card-header">Purchased Assets</h5>
-        <div class="card-body htmx-container table-responsive"
-          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?purchase_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'plugins:netbox_inventory:asset_list' purchase_id=object.pk %}
         {% if perms.netbox_inventory.add_asset %}
           <div class="card-footer text-end noprint">
             <a href="{% url 'plugins:netbox_inventory:asset_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -62,26 +62,30 @@
   <div class="row mb-3">
     <div class="col col-md-12">
       <div class="card">
-        <h5 class="card-header">Deliveries</h5>
+        <h5 class="card-header">
+          Deliveries
+          {% if perms.netbox_inventory.add_delivery %}
+            <div class="card-actions">
+              <a href="{% url 'plugins:netbox_inventory:delivery_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+                <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a Delivery
+              </a>
+            </div>
+          {% endif %}
+        </h5>
         {% htmx_table 'plugins:netbox_inventory:delivery_list' purchase_id=object.pk %}
-        {% if perms.netbox_inventory.add_delivery %}
-          <div class="card-footer text-end noprint">
-            <a href="{% url 'plugins:netbox_inventory:delivery_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-              <i class="mdi mdi-plus-thick" aria-hidden="true"></i>Add a Delivery
-            </a>
-          </div>
-        {% endif %}
       </div>
       <div class="card">
-        <h5 class="card-header">Purchased Assets</h5>
+        <h5 class="card-header">
+          Purchased Assets
+          {% if perms.netbox_inventory.add_asset %}
+            <div class="card-actions">
+              <a href="{% url 'plugins:netbox_inventory:asset_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+                <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
+              </a>
+            </div>
+          {% endif %}
+        </h5>
         {% htmx_table 'plugins:netbox_inventory:asset_list' purchase_id=object.pk %}
-        {% if perms.netbox_inventory.add_asset %}
-          <div class="card-footer text-end noprint">
-            <a href="{% url 'plugins:netbox_inventory:asset_add' %}?purchase={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-              <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Asset
-            </a>
-          </div>
-        {% endif %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/purchase.html
+++ b/netbox_inventory/templates/netbox_inventory/purchase.html
@@ -15,42 +15,40 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Purchase</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ object.name }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Supplier</th>
-              <td>{{ object.supplier|linkify }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Status</th>
-              <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
-            </tr>
-            <tr>
-              <th scope="row">Date</th>
-              <td>{{ object.date|isodate|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Description</th>
-              <td>{{ object.description|placeholder }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Deliveries</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:delivery_list' %}?purchase_id={{ object.pk }}">{{ delivery_count }}</a>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Assets</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:asset_list' %}?purchase_id={{ object.pk }}">{{ asset_count }}</a>
-              </td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Supplier</th>
+            <td>{{ object.supplier|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Status</th>
+            <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Date</th>
+            <td>{{ object.date|isodate|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Deliveries</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:delivery_list' %}?purchase_id={{ object.pk }}">{{ delivery_count }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Assets</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:asset_list' %}?purchase_id={{ object.pk }}">{{ asset_count }}</a>
+            </td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -61,10 +61,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Supplied Assets</h5>
-        <div class="card-body htmx-container table-responsive"
-          hx-get="{% url 'plugins:netbox_inventory:asset_list' %}?supplier_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'plugins:netbox_inventory:asset_list' supplier_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -19,36 +19,34 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Supplier</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th scope="row">Name</th>
-              <td>{{ object.name }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Description</th>
-              <td>{{ object.description }}</td>
-            </tr>
-            <tr>
-              <th scope="row">Purchases</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:purchase_list' %}?supplier_id={{ object.pk }}">{{ purchase_count }}</a>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Deliveries</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:delivery_list' %}?supplier_id={{ object.pk }}">{{ delivery_count }}</a>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Assets</th>
-              <td>
-                <a href="{% url 'plugins:netbox_inventory:asset_list' %}?supplier_id={{ object.pk }}">{{ asset_count }}</a>
-              </td>
-            </tr>
-          </table>
-        </div>
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Purchases</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:purchase_list' %}?supplier_id={{ object.pk }}">{{ purchase_count }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Deliveries</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:delivery_list' %}?supplier_id={{ object.pk }}">{{ delivery_count }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Assets</th>
+            <td>
+              <a href="{% url 'plugins:netbox_inventory:asset_list' %}?supplier_id={{ object.pk }}">{{ asset_count }}</a>
+            </td>
+          </tr>
+        </table>
       </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}

--- a/netbox_inventory/templates/netbox_inventory/supplier.html
+++ b/netbox_inventory/templates/netbox_inventory/supplier.html
@@ -8,7 +8,7 @@
 
 {% block extra_controls %}
   {% if perms.netbox_inventory.add_purchase %}
-    <a href="{% url 'plugins:netbox_inventory:purchase_add' %}?supplier={{ object.pk }}" class="btn btn-sm btn-primary">
+    <a href="{% url 'plugins:netbox_inventory:purchase_add' %}?supplier={{ object.pk }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add purchase
     </a>
   {% endif %}

--- a/netbox_inventory/tests/asset/test_api.py
+++ b/netbox_inventory/tests/asset/test_api.py
@@ -1,5 +1,6 @@
 from copy import copy
-from django.contrib.contenttypes.models import ContentType
+
+from core.models import ObjectType
 from dcim.models import Device, DeviceRole, DeviceType, InventoryItem, Manufacturer, ModuleType, Site
 from users.models import ObjectPermission
 from utilities.testing import APIViewTestCases, disable_warnings
@@ -34,7 +35,7 @@ class AssetTest(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         update_data = {'device':self.device1.pk}
 
@@ -62,7 +63,7 @@ class AssetTest(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         update_data = {'device':self.device2.pk}
 
@@ -84,7 +85,7 @@ class AssetTest(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         update_data = {'inventoryitem':self.inventoryitem1.pk}
 
@@ -106,7 +107,7 @@ class AssetTest(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         create_data = self.create_data[2]
         response = self.client.post(self._get_list_url(), create_data, format='json', **self.header)
@@ -124,7 +125,7 @@ class AssetTest(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         create_data = copy(self.create_data[0])
         create_data['serial'] = ''

--- a/netbox_inventory/tests/asset/test_api.py
+++ b/netbox_inventory/tests/asset/test_api.py
@@ -18,7 +18,7 @@ class AssetTest(
         APIViewTestCases.UpdateObjectViewTestCase,
         APIViewTestCases.DeleteObjectViewTestCase):
     model = Asset
-    brief_fields = ['display', 'id', 'serial', 'url']
+    brief_fields = ['display', 'id', 'name', 'serial', 'url']
 
     bulk_update_data = {
         'status': 'used',

--- a/netbox_inventory/tests/asset/test_views.py
+++ b/netbox_inventory/tests/asset/test_views.py
@@ -1,6 +1,6 @@
-from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 
+from core.models import ObjectType
 from dcim.models import Manufacturer, DeviceType, DeviceRole, Device, Site
 from users.models import ObjectPermission
 from utilities.testing import post_data, ViewTestCases
@@ -108,8 +108,8 @@ class AssetTestCase(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
-        obj_perm.object_types.add(ContentType.objects.get_for_model(Device))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(Device))
 
         asset = Asset.objects.create(
             status='stored',
@@ -160,7 +160,7 @@ class AssetTestCase(
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         supplier1 = Supplier.objects.create(
             name='Supplier1-autoset',

--- a/netbox_inventory/tests/asset/test_views_reassign.py
+++ b/netbox_inventory/tests/asset/test_views_reassign.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
 
+from core.models import ObjectType
 from dcim.models import Manufacturer, DeviceType, DeviceRole, Device, InventoryItem, Module, ModuleBay, ModuleType, Site
 from extras.choices import ObjectChangeActionChoices
 from extras.models import ObjectChange
@@ -137,7 +138,7 @@ class AssetReassignBase():
         )
         obj_perm.save()
         obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         # Try GET with model-level permission
         self.assertHttpStatus(self.client.get(self._get_url('edit', instance)), 200)

--- a/netbox_inventory/tests/delivery/test_api.py
+++ b/netbox_inventory/tests/delivery/test_api.py
@@ -11,7 +11,7 @@ class DeliveryTest(
         APIViewTestCases.UpdateObjectViewTestCase,
         APIViewTestCases.DeleteObjectViewTestCase):
     model = Delivery
-    brief_fields = ['date', 'display', 'id', 'name', 'url']
+    brief_fields = ['date', 'description', 'display', 'id', 'name', 'url']
 
     bulk_update_data = {
         'description': 'new description',

--- a/netbox_inventory/tests/purchase/test_api.py
+++ b/netbox_inventory/tests/purchase/test_api.py
@@ -11,7 +11,7 @@ class PurchaseTest(
         APIViewTestCases.UpdateObjectViewTestCase,
         APIViewTestCases.DeleteObjectViewTestCase):
     model = Purchase
-    brief_fields = ['date', 'display', 'id', 'name', 'status', 'supplier', 'url']
+    brief_fields = ['date', 'description', 'display', 'id', 'name', 'status', 'supplier', 'url']
 
     bulk_update_data = {
         'description': 'new description',

--- a/netbox_inventory/tests/supplier/test_api.py
+++ b/netbox_inventory/tests/supplier/test_api.py
@@ -11,7 +11,7 @@ class SupplierTest(
         APIViewTestCases.UpdateObjectViewTestCase,
         APIViewTestCases.DeleteObjectViewTestCase):
     model = Supplier
-    brief_fields = ['display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Supplier 4',

--- a/netbox_inventory/tests/supplier/test_views.py
+++ b/netbox_inventory/tests/supplier/test_views.py
@@ -114,7 +114,7 @@ class ContactAssignmentTestCase(
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
         cls.form_data = {
-            'content_type': ContentType.objects.get_for_model(Supplier).pk,
+            'object_type': ContentType.objects.get_for_model(Supplier).pk,
             'object_id': suppliers[3].pk,
             'contact': contacts[3].pk,
             'role': contact_roles[3].pk,
@@ -133,6 +133,6 @@ class ContactAssignmentTestCase(
             url = reverse('tenancy:contactassignment_add')
             content_type = ContentType.objects.get_for_model(Supplier).pk
             object_id = Supplier.objects.first().pk
-            return f"{url}?content_type={content_type}&object_id={object_id}"
+            return f"{url}?object_type={content_type}&object_id={object_id}"
 
         return super()._get_url(action, instance=instance)

--- a/netbox_inventory/views/asset_create.py
+++ b/netbox_inventory/views/asset_create.py
@@ -60,8 +60,3 @@ class AssetInventoryItemCreateView(AssetCreateView):
 
     def get_object(self, **kwargs):
         return InventoryItem(assigned_asset=self.asset)
-
-    def get_extra_context(self, request, instance):
-        context = super().get_extra_context(request, instance)
-        context['template_extends'] = 'dcim/inventoryitem_edit.html'
-        return context

--- a/netbox_inventory/views/delivery.py
+++ b/netbox_inventory/views/delivery.py
@@ -1,5 +1,5 @@
 from netbox.views import generic
-from utilities.utils import count_related
+from utilities.query import count_related
 from .. import filtersets, forms, models, tables
 
 __all__ = (

--- a/netbox_inventory/views/inventoryitem_type.py
+++ b/netbox_inventory/views/inventoryitem_type.py
@@ -1,5 +1,5 @@
 from netbox.views import generic
-from utilities.utils import count_related
+from utilities.query import count_related
 from .. import filtersets, forms, models, tables
 
 __all__ = (

--- a/netbox_inventory/views/purchase.py
+++ b/netbox_inventory/views/purchase.py
@@ -1,5 +1,5 @@
 from netbox.views import generic
-from utilities.utils import count_related
+from utilities.query import count_related
 from .. import filtersets, forms, models, tables
 
 __all__ = (

--- a/netbox_inventory/views/supplier.py
+++ b/netbox_inventory/views/supplier.py
@@ -1,6 +1,6 @@
 from netbox.views import generic
 from tenancy.views import ObjectContactsView
-from utilities.utils import count_related
+from utilities.query import count_related
 from utilities.views import register_model_view
 from .. import filtersets, forms, models, tables
 


### PR DESCRIPTION
List of items from [official plugin porting guide](https://docs.netbox.dev/en/stable/plugins/development/migration-v4/#obsolete-custom-css-classes):

    General
        ✅ Python support
        ✅ Plugin resources relocated
        ☑️ ContentType renamed to ObjectType (I think I fixed those that need to be fixed)
    Views
        🟡 View actions must be dictionaries (not in use) 
    Forms
        ✅ Remove BootstrapMixin
        ✅ Update Fieldset definitions
    Navigation
        ✅ Remove button colors
    UI Layout
        ✅ Renamed template blocks
        🟡 Utilize flex controls (not in use)
        🟡 Check column offsets (not in use)
        ✅ Tables inside cards
        ✅ Remove btn-sm class from buttons
        ✅ Update bg-$color classes
        🟡 Obsolete custom CSS classes (not in use)
    REST API
        ✅ Extend serializer for brief mode
        ✅ Include description fields in brief mode
    GraphQL
        Change schema.py
        Change types.py
        Change filters.py

Other stuff:

    ✅ count_related moved
    asset_edit template - check
    check all other complex templates
    ✅ The annotated_date template filter and annotated_now template tag have been removed.
    ✅ move all nested table action buttons from footer to header
    ✅ change how htmx tables are rendered (new macro) 
    on custom tabs for core objects (tabs folder), fix controls button layout
    ✅ update warranty progress bar component
    update render_table to htmx
    investigate image attachments includes if it's possible to hide object type & parent columns

