### PR TITLE
Add id to search for asset attributes

### DIFF
--- a/netbox_inventory/filtersets.py
+++ b/netbox_inventory/filtersets.py
@@ -225,7 +225,8 @@ class AssetFilterSet(NetBoxModelFilterSet):
 
     def search(self, queryset, name, value):
         query = (
-            Q(serial__icontains=value)
+            Q(id__contains=value)
+            | Q(serial__icontains=value)
             | Q(name__icontains=value)
             | Q(asset_tag__icontains=value)
             | Q(device_type__model__icontains=value)


### PR DESCRIPTION
The asset ID is often used as identifier for assets. This patch adds id to the searched attributes in the asset listing.