### PR TITLE
remove option to filter for None in some location related filters

### DIFF
--- a/netbox_inventory/forms/filters.py
+++ b/netbox_inventory/forms/filters.py
@@ -217,7 +217,6 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
     installed_location_id = DynamicModelMultipleChoiceField(
         queryset=Location.objects.all(),
         required=False,
-        null_option='None',
         query_params={
             'site_id': '$installed_site_id',
         },
@@ -227,7 +226,6 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
     installed_rack_id = DynamicModelMultipleChoiceField(
         queryset=Rack.objects.all(),
         required=False,
-        null_option='None',
         query_params={
             'site_id': '$installed_site_id',
             'location_id': '$installed_location_id',
@@ -238,7 +236,6 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
     installed_device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        null_option='None',
         query_params={
             'site_id': '$installed_site_id',
             'location_id': '$installed_location_id',
@@ -255,7 +252,6 @@ class AssetFilterForm(NetBoxModelFilterSetForm):
     located_location_id = DynamicModelMultipleChoiceField(
         queryset=Location.objects.all(),
         required=False,
-        null_option='None',
         query_params={
             'site_id': '$located_site_id',
         },

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -131,13 +131,15 @@ def query_located(queryset, field_name, values, assets_shown='all'):
         * queryset - queryset of Asset model
         * field_name - 'site' or 'location' or 'rack'
         * values - list of PKs of location types to filter on
-        * assets_shown - 'all' or 'installd' or 'stored'
+        * assets_shown - 'all' or 'installed' or 'stored'
     """
     q_installed = (
         Q(**{f'device__{field_name}__in':values})|
         Q(**{f'module__device__{field_name}__in':values})|
         Q(**{f'inventoryitem__device__{field_name}__in':values})
     )
+
+    # Q expressions for stored
     if field_name == 'rack':
         # storage in rack is not supported
         # generate Q() that matches none
@@ -147,11 +149,12 @@ def query_located(queryset, field_name, values, assets_shown='all'):
             Q(**{f'storage_location__in':values})&
             Q(status=get_status_for('stored'))
         )
-    else:
+    elif field_name == 'site':
         q_stored = (
-            Q(**{f'storage_location__{field_name}__in':values})&
+            Q(**{f'storage_location__site__in':values})&
             Q(status=get_status_for('stored'))
         )
+
     if assets_shown == 'all':
         q = q_installed | q_stored
     elif assets_shown == 'installed':


### PR DESCRIPTION
some fields don't make sense to filter for none. and some result in queries that return unexpected results

Removed option None from:

- Installed at location
- Installed in rack
- Installed in device
- Located at location

