### PR TITLE
allow changing device_type and module_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ PLUGINS_CONFIG = {
 | `top_level_menu` | `True`| Add netbox-inventory to the top level of netbox navigation menu under Inventory heading. If set to False the plugin will add a menu item under the Plugins menu item. This setting is only valid under netbox v3.4 and newer.
 | `used_status_name` | `'used'`| Status that indicates asset is in use. See "Automatic management of asset status" below for more info on this setting.
 | `stored_status_name` | `'stored'`| Status that indicates asset is in storage. See "Automatic management of asset status" below for more info on this setting.
-| `sync_hardware_serial_asset_tag` | `False` | When an asset is assigned or unassigned to a device, module or inventory item, update its serial number and asset tag to be in sync with the asset? |
+| `sync_hardware_serial_asset_tag` | `False` | When an asset is assigned or unassigned to a device, module or inventory item, update its serial number and asset tag to be in sync with the asset? For device and module device type or module type is also updated to match asset. For inventory items, manufacturer and part ID are updated to match asset. |
 | `asset_import_create_purchase` | `False` | When importing assets, automatically create any given purchase, delivery or supplier if it doesn't exist already |
 | `asset_import_create_device_type` | `False` | When importing a device type asset, automatically create manufacturer and/or device type if it doesn't exist |
 | `asset_import_create_module_type` | `False` | When importing a module type asset, automatically create manufacturer and/or device type if it doesn't exist |

--- a/netbox_inventory/forms/reassign.py
+++ b/netbox_inventory/forms/reassign.py
@@ -99,6 +99,8 @@ class AssetReassignMixin(forms.Form):
         try:
             # update hardware assignment and validate data
             setattr(asset, asset.kind, instance)
+            # signal to assset.clean() methods to not validate _type match beetween asset and hw
+            asset._in_reassign = True
             asset.full_clean(exclude=(asset.kind,))
         except ValidationError as e:
             # ValidationError raised for device or module field
@@ -133,7 +135,6 @@ class AssetDeviceReassignForm(AssetReassignMixin, NetBoxModelForm):
         query_params={
             'kind': 'device',
             'is_assigned': False,
-            'device_type_id': '$device_type',
             'storage_site_id': '$storage_site',
             'storage_location_id': '$storage_location',
         },
@@ -143,16 +144,7 @@ class AssetDeviceReassignForm(AssetReassignMixin, NetBoxModelForm):
 
     class Meta:
         model = Device
-        # device_type is here only to allow setting assigned_asset query_params on device_type
-        fields = AssetReassignMixin.Meta.fields + ('device_type',)
-        widgets = {'device_type': forms.HiddenInput,}
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # limit asset selection based on current device.device_type
-        self.initial['device_type'] = self.instance.device_type_id
-        assigned_asset_field = self.fields['assigned_asset']
-        assigned_asset_field.queryset = Asset.objects.filter(device_type=self.instance.device_type, device__isnull=True)
+        fields = AssetReassignMixin.Meta.fields
 
 
 class AssetModuleReassignForm(AssetReassignMixin, NetBoxModelForm):
@@ -163,7 +155,6 @@ class AssetModuleReassignForm(AssetReassignMixin, NetBoxModelForm):
         query_params={
             'kind': 'module',
             'is_assigned': False,
-            'module_type_id': '$module_type',
             'storage_site_id': '$storage_site',
             'storage_location_id': '$storage_location',
         },
@@ -173,16 +164,7 @@ class AssetModuleReassignForm(AssetReassignMixin, NetBoxModelForm):
 
     class Meta:
         model = Module
-        # module_type is here only to allow setting assigned_asset query_params on module_type
-        fields = AssetReassignMixin.Meta.fields + ('module_type',)
-        widgets = {'module_type': forms.HiddenInput,}
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # limit asset selection based on current module.module_type
-        self.initial['module_type'] = self.instance.module_type_id
-        assigned_asset_field = self.fields['assigned_asset']
-        assigned_asset_field.queryset = Asset.objects.filter(module_type=self.instance.module_type, module__isnull=True)
+        fields = AssetReassignMixin.Meta.fields
 
 
 class AssetInventoryItemReassignForm(AssetReassignMixin, NetBoxModelForm):

--- a/netbox_inventory/models.py
+++ b/netbox_inventory/models.py
@@ -324,8 +324,11 @@ class Asset(NetBoxModel, ImageAttachmentsMixin):
 
         # e.g.: self.device_type and self.device.device_type must match
         # InventoryItem does not have FK to InventoryItemType
-        if kind != 'inventoryitem' and hw and _type != getattr(hw, kind+'_type'):
-            raise ValidationError({kind: f'{kind} type of {kind} does not match {kind} type of asset'})
+        if kind != 'inventoryitem':
+            if not getattr(self, '_in_reassign', False):
+                # but don't check if we are reassigning asset to another device
+                if hw and _type != getattr(hw, kind+'_type'):
+                    raise ValidationError({kind: f'{kind} type of {kind} does not match {kind} type of asset'})
         # ensure only one hardware is set and that it is correct kind
         # e.g. if self.device_type is set, we cannot have self.module or self.inventoryitem set
         for hw_other in hw_others:

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -103,6 +103,13 @@ def asset_set_new_hw(asset, hw):
     if hw.asset_tag != new_asset_tag:
         hw.asset_tag = new_asset_tag
         hw_save = True
+    # handle changing of model (<kind>_type)
+    if asset.kind in ['device', 'module']:
+        asset_type = getattr(asset, asset.kind+'_type')
+        hw_type = getattr(hw, asset.kind+'_type')
+        if asset_type != hw_type:
+            setattr(hw, asset.kind+'_type', asset_type)
+            hw_save = True
     # for inventory items also set manufacturer and part_number
     if asset.inventoryitem_type:
         if hw.manufacturer != asset.inventoryitem_type.manufacturer:


### PR DESCRIPTION
When reassigning asset for a device or module, allow selecting an asset with a different device_type or module_type as the current one on device (or module).

If setting `sync_hardware_serial_asset_tag` is `True`, the device or module device type/module_type will be updated automatically as well. However updating any components of device or module to match the new type is not handled by this plugin.
