### PR TITLE
ensure change snapshots are created for hardware

### DIFF
--- a/netbox_inventory/models.py
+++ b/netbox_inventory/models.py
@@ -360,6 +360,10 @@ class Asset(NetBoxModel, ImageAttachmentsMixin):
             return None
         old_hw = get_prechange_field(self, self.kind)
         new_hw = getattr(self, self.kind)
+        if old_hw:
+            old_hw.snapshot()
+        if new_hw:
+            new_hw.snapshot()
         old_serial = get_prechange_field(self, 'serial')
         old_asset_tag = get_prechange_field(self, 'asset_tag')
         if not new_hw and old_hw and clear_old_hw:


### PR DESCRIPTION
ensure change snapshots are created for hardware when changing hw - asset relations

when going through "edit assignment" to change a device related to asset, there was not snapshot created for old or new device, so object change diff view was incomplete.