### PR TITLE
add ability to mark multiple asset statuses as used or stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ PLUGINS_CONFIG = {
 |---------|---------------|-------------|
 | `top_level_menu` | `True`| Add netbox-inventory to the top level of netbox navigation menu under Inventory heading. If set to False the plugin will add a menu item under the Plugins menu item.
 | `used_status_name` | `'used'`| Status that indicates asset is in use. See "Automatic management of asset status" below for more info on this setting.
+| `used_additional_status_names` | `[]` (empty list) | List of statuses that are also considered as in use.
 | `stored_status_name` | `'stored'`| Status that indicates asset is in storage. See "Automatic management of asset status" below for more info on this setting.
+| `stored_additional_status_names` | `['retired',]`| List of statuses that are also considered as not in use by various filters.
 | `sync_hardware_serial_asset_tag` | `False` | When an asset is assigned or unassigned to a device, module or inventory item, update its serial number and asset tag to be in sync with the asset? For device and module device type or module type is also updated to match asset. For inventory items, manufacturer and part ID are updated to match asset. |
 | `asset_import_create_purchase` | `False` | When importing assets, automatically create any given purchase, delivery or supplier if it doesn't exist already |
 | `asset_import_create_device_type` | `False` | When importing a device type asset, automatically create manufacturer and/or device type if it doesn't exist |
@@ -168,6 +170,8 @@ FIELD_CHOICES = {
     ),
 }
 ```
+
+If you add more statuses, you should also adjust `used_additional_status_names` and `stored_additional_status_names` settings.
 
 ## Common questions
 

--- a/netbox_inventory/__init__.py
+++ b/netbox_inventory/__init__.py
@@ -14,7 +14,9 @@ class NetBoxInventoryConfig(PluginConfig):
     default_settings = {
         'top_level_menu': True,
         'used_status_name': 'used',
+        'used_additional_status_names': list(),
         'stored_status_name': 'stored',
+        'stored_additional_status_names': ['retired',],
         'sync_hardware_serial_asset_tag': False,
         'asset_import_create_purchase': False,
         'asset_import_create_device_type': False,

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -35,7 +35,7 @@ def get_status_for(status):
         return None
     if status_name not in dict(AssetStatusChoices):
         raise ImproperlyConfigured(
-            f'Configuration defines status {status_name}, but not defined in AssetStatusChoices'
+            f'netbox_inventory plugin configuration defines status {status_name}, but it is not defined in FIELD_CHOICES["netbox_inventory.Asset.status"]'
         )
     return status_name
 

--- a/netbox_inventory/utils.py
+++ b/netbox_inventory/utils.py
@@ -40,6 +40,21 @@ def get_status_for(status):
     return status_name
 
 
+def get_all_statuses_for(status):
+    status_names = get_plugin_setting(status + '_additional_status_names')
+    status_names = set(status_names)
+    # add primary status
+    if primary_status := get_status_for(status):
+        status_names.add(primary_status)
+    if len(status_names) < 1:
+        return None
+    if extra_statuses := status_names.difference(set(dict(AssetStatusChoices))):
+        raise ImproperlyConfigured(
+            f'netbox_inventory plugin configuration defines statuses {extra_statuses}, but these are not defined in FIELD_CHOICES["netbox_inventory.Asset.status"]'
+        )
+    return list(status_names)
+
+
 def get_tags_that_protect_asset_from_deletion():
     """Return a list of tags that prevent an asset from being deleted.
 
@@ -160,12 +175,12 @@ def query_located(queryset, field_name, values, assets_shown='all'):
     elif field_name == 'location':
         q_stored = (
             Q(**{f'storage_location__in':values})&
-            Q(status=get_status_for('stored'))
+            Q(status__in=get_all_statuses_for('stored'))
         )
     elif field_name == 'site':
         q_stored = (
             Q(**{f'storage_location__site__in':values})&
-            Q(status=get_status_for('stored'))
+            Q(status__in=get_all_statuses_for('stored'))
         )
 
     if assets_shown == 'all':


### PR DESCRIPTION
Add two more plugin settings: `used_additional_status_names` and `stored_additional_status_names`. These are used when filtering assets by location - any asset that has storage location (or site) set to a location and has status from  `stored_additional_status_names` in addition to `stored_status_name` will be considered as currently stored at location.
