### PR TITLE
fix display of current location...

### DIFF
--- a/netbox_inventory/models/assets.py
+++ b/netbox_inventory/models/assets.py
@@ -395,7 +395,9 @@ class Asset(NetBoxModel, ImageAttachmentsMixin):
     @property
     def current_location(self):
         installed = self.installed_location
-        if installed:
+        # we can have an installed site but no installed location
+        # so return None in that case
+        if installed or self.installed_site:
             return installed
         return self.storage_location
 


### PR DESCRIPTION
…when installed site is set but installed location is not

Previously it showed storage location in such cases. Now it will show None.