### PR TITLE
Fixes #245: Disable column sorting for current asset location

### DIFF
--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -197,10 +197,12 @@ class AssetTable(NetBoxTable):
     current_site = tables.Column(
         linkify=True,
         verbose_name='Current Site',
+        orderable=False,
     )
     current_location = tables.Column(
         linkify=True,
         verbose_name='Current Location',
+        orderable=False,
     )
     warranty_progress = columns.TemplateColumn(
         template_code=WARRANTY_PROGRESSBAR,


### PR DESCRIPTION
The current location of an asset is mapped to either its assigned object's location or its storage location. Since these are multiple database fields that cannot be clearly sorted without complex annotations, sorting will be disabled for these columns to prevent errors when using the table.

Fixes: #245 