### PR TITLE
Remove superflous audit trail source column

### DIFF
--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -648,14 +648,10 @@ class AuditTrailSourceTable(NetBoxTable):
             'id',
             'name',
             'description',
-            'lifetime',
             'comments',
             'actions',
         )
-        default_columns = (
-            'name',
-            'lifetime',
-        )
+        default_columns = ('name',)
 
 
 class AuditTrailTable(NetBoxTable):

--- a/netbox_inventory/tests/audittrailsource/test_filtersets.py
+++ b/netbox_inventory/tests/audittrailsource/test_filtersets.py
@@ -13,7 +13,6 @@ from netbox_inventory.models import (
 class AuditTrailSourceTestCase(TestCase, ChangeLoggedFilterSetTests):
     queryset = AuditTrailSource.objects.all()
     filterset = AuditTrailSourceFilterSet
-    ignore_fields = ('lifetime',)
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
The lifetime column was a leftover from previous development intended for audit trails and never reached production. It can be removed from tables and filtersets because it is not available on the related model.