### PR TITLE
Fix asset columns on core netbox tables

### DIFF
--- a/netbox_inventory/tables.py
+++ b/netbox_inventory/tables.py
@@ -720,7 +720,7 @@ class AuditTrailTable(NetBoxTable):
 asset_count = columns.LinkedCountColumn(
     viewname='plugins:netbox_inventory:asset_list',
     url_params={'device_type_id': 'pk'},
-    verbose_name=_('Assets'),
+    verbose_name=_('Asset Count'),
     accessor='assets__count',
     orderable=False,
 )
@@ -731,7 +731,7 @@ register_table_column(asset_count, 'assets', DeviceTypeTable)
 asset_count = columns.LinkedCountColumn(
     viewname='plugins:netbox_inventory:asset_list',
     url_params={'module_type_id': 'pk'},
-    verbose_name=_('Assets'),
+    verbose_name=_('AsseAsset Countts'),
     accessor='assets__count',
     orderable=False,
 )
@@ -742,7 +742,7 @@ register_table_column(asset_count, 'assets', ModuleTypeTable)
 asset_count = columns.LinkedCountColumn(
     viewname='plugins:netbox_inventory:asset_list',
     url_params={'rack_type_id': 'pk'},
-    verbose_name=_('Assets'),
+    verbose_name=_('Asset Count'),
     accessor='assets__count',
     orderable=False,
 )
@@ -753,7 +753,7 @@ register_table_column(asset_count, 'assets', RackTypeTable)
 asset_count = columns.LinkedCountColumn(
     viewname='plugins:netbox_inventory:asset_list',
     url_params={'storage_location_id': 'pk'},
-    verbose_name=_('Assets'),
+    verbose_name=_('Asset Count'),
     # accessor='assets__count',
     accessor=tables.A('assets__count_with_children'),
     orderable=False,


### PR DESCRIPTION
fixes #271

Renamed Asset column to Asset counts, to match existing column names (eg. Device count).

I can't find a way to enable sorting on `LinkedCountColumns` injected into tables with `register_table_column` so I disabled ordering so at least we don't break netbox for users