### PR TITLE
Add copy-to-clipboard buttons for serial number and asset tag on Asset detail page

### DIFF
--- a/netbox_inventory/templates/netbox_inventory/asset.html
+++ b/netbox_inventory/templates/netbox_inventory/asset.html
@@ -28,11 +28,29 @@
           </tr>
           <tr>
             <th scope="row">Asset Tag</th>
-            <td class="font-monospace">{{ object.asset_tag|placeholder }}</td>
+            <td class="font-monospace d-flex justify-content-between align-items-center">
+              {% if object.asset_tag %}
+                <span id="attr_asset_tag">{{ object.asset_tag }}</span>
+                <a class="btn btn-sm btn-primary copy-content" data-clipboard-target="#attr_asset_tag" title="Copy to clipboard">
+                  <i class="mdi mdi-content-copy"></i>
+                </a>
+              {% else %}
+                {{ ''|placeholder }}
+              {% endif %}
+            </td>
           </tr>
           <tr>
             <th scope="row">Serial Number</th>
-            <td class="font-monospace">{{ object.serial|placeholder }}</td>
+            <td class="font-monospace d-flex justify-content-between align-items-center">
+              {% if object.serial %}
+                <span id="attr_serial">{{ object.serial }}</span>
+                <a class="btn btn-sm btn-primary copy-content" data-clipboard-target="#attr_serial" title="Copy to clipboard">
+                  <i class="mdi mdi-content-copy"></i>
+                </a>
+              {% else %}
+                {{ ''|placeholder }}
+              {% endif %}
+            </td>
           </tr>
           <tr>
             <th scope="row">Status</th>


### PR DESCRIPTION
## What this PR does
Adds copy-to-clipboard buttons for the Serial Number and Asset Tag fields 
on the Asset detail page, consistent with the same functionality on the 
Device detail page in NetBox core (introduced in netbox-community/netbox#12499).

## How it works
Uses the existing NetBox `copy-content` CSS class and clipboard.js mechanism 
already present in NetBox. The button only appears when the field is not empty.