### PR TITLE
change to django querystring template tag where possible

### DIFF
--- a/netbox_inventory/templates/netbox_inventory/auditflow_run.html
+++ b/netbox_inventory/templates/netbox_inventory/auditflow_run.html
@@ -30,6 +30,8 @@
   <ul class="nav nav-tabs" role="tablist">
     {% for page in flow_pages %}
       <li class="nav-item" role="presentation">
+        {# FIXME "querystring request ..." -> "querystring ..." under netbox v4.7 #}
+        {# https://github.com/netbox-community/netbox/issues/21331 #}
         <a class="nav-link{% if tab == page.pk %} active{% endif %}" href="{% querystring request tab=page.pk page=None per_page=None %}">{{ page.page.name }}</a>
       </li>
     {% endfor %}

--- a/netbox_inventory/templates/netbox_inventory/inc/asset_edit_header.html
+++ b/netbox_inventory/templates/netbox_inventory/inc/asset_edit_header.html
@@ -1,11 +1,10 @@
-{% load helpers %}
 {# renders tab navbar for asset form #}
 
 <ul class="nav nav-tabs px-3">
   <li class="nav-item">
       <a
           class="nav-link {% if active_tab == 'add' %}active{% endif %}"
-          href="{% url 'plugins:netbox_inventory:asset_add' %}{% querystring request %}"
+          href="{% url 'plugins:netbox_inventory:asset_add' %}{% querystring %}"
       >
           {% if object.pk %}Edit{% else %}Create{% endif %}
       </a>
@@ -14,7 +13,7 @@
   <li class="nav-item">
       <a
           class="nav-link {% if active_tab == 'bulk_add' %}active{% endif %}"
-          href="{% url 'plugins:netbox_inventory:asset_bulk_add' %}{% querystring request %}"
+          href="{% url 'plugins:netbox_inventory:asset_bulk_add' %}{% querystring %}"
       >
           Bulk Create
       </a>


### PR DESCRIPTION
> netbox/utilities/templatetags/helpers.py:403: FutureWarning: The querystring template tag is deprecated and will be removed in a future release. Use the built-in Django querystring tag instead.

Left it as is in netbox_inventory/templates/netbox_inventory/auditflow_run.html since this template also uses vewname tag and I cannot remove `load helpers`. Just added a comment to remind me to update querystring filter args once netbox's version is removed.
